### PR TITLE
Implementation of some RPC methods for queries to storage.

### DIFF
--- a/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/Constants.java
+++ b/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
 
     public static final String AUTO_REGISTER_TYPES_ARG = "types";
     public static final String PAIR_FACTORY_METHOD = "of";
+    public static final String RESOLVE_AND_INJECT_METHOD = "resolveAndInjectOrNull";
 
     public static final String ENCODE_METHOD_NAME = "encode";
     public static final String DECODE_METHOD_NAME = "decode";

--- a/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/decoder/RpcDecoderAnnotatedClass.java
+++ b/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/decoder/RpcDecoderAnnotatedClass.java
@@ -121,6 +121,7 @@ public class RpcDecoderAnnotatedClass {
                 typeVarMap,
                 String.format("%s[$L].%s", DECODERS_ARG, DECODER_UNSAFE_ACCESSOR),
                 String.format("%s[$L].%s", DECODERS_ARG, READER_UNSAFE_ACCESSOR),
+                READER_UNSAFE_ACCESSOR,
                 DECODER_REGISTRY,
                 SCALE_READER_REGISTRY);
         val scaleAnnotationParser = new ScaleAnnotationParser(context);

--- a/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/encoder/RpcEncoderAnnotatedClass.java
+++ b/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/encoder/RpcEncoderAnnotatedClass.java
@@ -120,6 +120,7 @@ public class RpcEncoderAnnotatedClass {
                 typeVarMap,
                 String.format("%s[$L].%s", ENCODERS_ARG, ENCODER_UNSAFE_ACCESSOR),
                 String.format("%s[$L].%s", ENCODERS_ARG, WRITER_UNSAFE_ACCESSOR),
+                WRITER_UNSAFE_ACCESSOR,
                 ENCODER_REGISTRY,
                 SCALE_WRITER_REGISTRY);
         val scaleAnnotationParser = new ScaleAnnotationParser(context);

--- a/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/sections/RpcMethodProcessor.java
+++ b/rpc/rpc-codegen/src/main/java/com/strategyobject/substrateclient/rpc/codegen/sections/RpcMethodProcessor.java
@@ -127,6 +127,7 @@ public abstract class RpcMethodProcessor<A extends Annotation> extends RpcInterf
                 EMPTY_TYPE_VAR_MAP,
                 String.format("%s[$L].%s", DECODERS_ARG, DECODER_UNSAFE_ACCESSOR),
                 String.format("%s[$L].%s", DECODERS_ARG, READER_UNSAFE_ACCESSOR),
+                READER_UNSAFE_ACCESSOR,
                 DECODER_REGISTRY,
                 SCALE_READER_REGISTRY);
 
@@ -184,6 +185,7 @@ public abstract class RpcMethodProcessor<A extends Annotation> extends RpcInterf
                 EMPTY_TYPE_VAR_MAP,
                 String.format("%s[$L].%s", ENCODERS_ARG, ENCODER_UNSAFE_ACCESSOR),
                 String.format("%s[$L].%s", ENCODERS_ARG, WRITER_UNSAFE_ACCESSOR),
+                WRITER_UNSAFE_ACCESSOR,
                 ENCODER_REGISTRY,
                 SCALE_WRITER_REGISTRY);
 
@@ -199,7 +201,7 @@ public abstract class RpcMethodProcessor<A extends Annotation> extends RpcInterf
         for (val param : method.getParameters()) {
             try {
                 processParameter(methodSpecBuilder, method, param, encoderCompositor, writerCompositor, scaleAnnotationParser, context);
-            } catch (Exception e){
+            } catch (Exception e) {
                 throw new ProcessingException(e, param, e.getMessage());
             }
         }

--- a/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/decoder/RpcDecoderProcessorTests.java
+++ b/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/decoder/RpcDecoderProcessorTests.java
@@ -8,6 +8,12 @@ import com.strategyobject.substrateclient.rpc.core.registries.RpcDecoderRegistry
 import lombok.val;
 import org.junit.jupiter.api.Test;
 
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,8 +62,20 @@ public class RpcDecoderProcessorTests {
         val decoder = registry.resolve(TestDecodable.class)
                 .inject(DecoderPair.of(registry.resolve(String.class), null));
 
-        Object source = gson.fromJson("{a: 4, b: \"123\", c: \"some\"}", Object.class);
-        val expected = new TestDecodable<>(4, "123", "some");
+        Object source = gson.fromJson("{\"a\":4,\"b\":\"123\",\"c\":\"some\"," +
+                        "\"d\":[\"1\",\"2\"],\"e\":{\"a\":1,\"b\":2},\"f\":\"0x04000000\"," +
+                        "\"g\":\"0x0c0500000002000000fdffffff\"}",
+                Object.class);
+        val expected = new TestDecodable<>(4,
+                "123",
+                "some",
+                Arrays.asList("1", "2"),
+                Stream.of(
+                                new AbstractMap.SimpleEntry<>("a", 1),
+                                new AbstractMap.SimpleEntry<>("b", 2))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+                4,
+                Arrays.asList(5, 2, -3));
 
         val actual = decoder.decode(source);
 

--- a/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/encoder/RpcEncoderProcessorTests.java
+++ b/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/encoder/RpcEncoderProcessorTests.java
@@ -6,10 +6,14 @@ import com.strategyobject.substrateclient.rpc.codegen.substitutes.TestEncodable;
 import com.strategyobject.substrateclient.rpc.core.EncoderPair;
 import com.strategyobject.substrateclient.rpc.core.RpcEncoder;
 import com.strategyobject.substrateclient.rpc.core.registries.RpcEncoderRegistry;
-import com.strategyobject.substrateclient.scale.ScaleUtils;
-import com.strategyobject.substrateclient.scale.writers.I32Writer;
 import lombok.val;
 import org.junit.jupiter.api.Test;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
@@ -68,9 +72,19 @@ public class RpcEncoderProcessorTests {
                                         )),
                                 null));
 
-        val source = new TestEncodable<>(4, "some", new TestEncodable.Subclass<>(123), true);
+        val source = new TestEncodable<>(4,
+                "some",
+                new TestEncodable.Subclass<>(123),
+                true,
+                Arrays.asList("a", "b"),
+                Stream.of(
+                                new AbstractMap.SimpleEntry<>("a", 1),
+                                new AbstractMap.SimpleEntry<>("b", 2))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+                Arrays.asList(2, 3));
         val expected = gson.fromJson(
-                "{\"a\":\"" + ScaleUtils.toHexString(4, new I32Writer()) + "\", \"b\": \"some\", \"c\": {\"a\": 123}, \"d\": true}",
+                "{\"a\":\"0x04000000\",\"b\":\"some\",\"c\":{\"a\":123},\"d\":true," +
+                        "\"e\":[\"a\",\"b\"],\"f\":{\"a\":1,\"b\":2},\"h\":\"0x080200000003000000\"}",
                 Object.class);
 
         val actual = gson.fromJson(

--- a/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/substitutes/TestDecodable.java
+++ b/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/substitutes/TestDecodable.java
@@ -1,24 +1,28 @@
 package com.strategyobject.substrateclient.rpc.codegen.substitutes;
 
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcDecoder;
+import com.strategyobject.substrateclient.scale.annotations.Scale;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
 
 @RpcDecoder
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class TestDecodable<T> {
-    public int a;
-    public String b;
-    public T c;
-
-    public TestDecodable() {
-
-    }
-
-    public TestDecodable(int a, String b, T c) {
-        this.a = a;
-        this.b = b;
-        this.c = c;
-    }
+    private int a;
+    private String b;
+    private T c;
+    private List<String> d;
+    private Map<String, Integer> e;
+    @Scale
+    private int f;
+    @Scale
+    private List<Integer> g;
 }

--- a/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/substitutes/TestEncodable.java
+++ b/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/substitutes/TestEncodable.java
@@ -7,26 +7,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+import java.util.Map;
+
 @RpcEncoder
 @Getter
 @Setter
+@AllArgsConstructor
 public class TestEncodable<T> {
     @Scale
-    public int a;
-    public String b;
-    public T c;
-    public boolean d;
-
-    public TestEncodable() {
-
-    }
-
-    public TestEncodable(int a, String b, T c, boolean d) {
-        this.a = a;
-        this.b = b;
-        this.c = c;
-        this.d = d;
-    }
+    private int a;
+    private String b;
+    private T c;
+    private boolean d;
+    private List<String> e;
+    private Map<String, Integer> f;
+    @Scale
+    private List<Integer> h;
 
     @Getter
     @Setter

--- a/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcRegistryHelper.java
+++ b/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcRegistryHelper.java
@@ -1,0 +1,32 @@
+package com.strategyobject.substrateclient.rpc.core;
+
+import com.strategyobject.substrateclient.rpc.core.registries.RpcDecoderRegistry;
+import com.strategyobject.substrateclient.rpc.core.registries.RpcEncoderRegistry;
+import lombok.val;
+
+public final class RpcRegistryHelper {
+    private RpcRegistryHelper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> RpcDecoder<T> resolveAndInjectOrNull(Class<T> clazz, DecoderPair<?>... dependencies) {
+        val target = (RpcDecoder<T>) RpcDecoderRegistry.getInstance().resolve(clazz);
+
+        if (target == null) {
+            return null;
+        }
+
+        return target.inject(dependencies);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> RpcEncoder<T> resolveAndInjectOrNull(Class<T> clazz, EncoderPair<?>... dependencies) {
+        val target = (RpcEncoder<T>) RpcEncoderRegistry.getInstance().resolve(clazz);
+
+        if (target == null) {
+            return null;
+        }
+
+        return target.inject(dependencies);
+    }
+}

--- a/rpc/rpc-sections/src/main/java/com/strategyobject/substrateclient/rpc/sections/State.java
+++ b/rpc/rpc-sections/src/main/java/com/strategyobject/substrateclient/rpc/sections/State.java
@@ -2,10 +2,10 @@ package com.strategyobject.substrateclient.rpc.sections;
 
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcCall;
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcInterface;
-import com.strategyobject.substrateclient.rpc.types.Metadata;
-import com.strategyobject.substrateclient.rpc.types.RuntimeVersion;
+import com.strategyobject.substrateclient.rpc.types.*;
 import com.strategyobject.substrateclient.scale.annotations.Scale;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @RpcInterface(section = "state")
@@ -16,4 +16,13 @@ public interface State {
     @RpcCall(method = "getMetadata")
     @Scale
     CompletableFuture<Metadata> getMetadata();
+
+    @RpcCall(method = "getKeys")
+    CompletableFuture<List<StorageKey>> getKeys(StorageKey key);
+
+    @RpcCall(method = "getStorage")
+    CompletableFuture<StorageData> getStorage(StorageKey key);
+
+    @RpcCall(method = "queryStorageAt")
+    CompletableFuture<List<StorageChangeSet>> queryStorageAt(List<StorageKey> keys);
 }

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/PairDecoder.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/PairDecoder.java
@@ -1,0 +1,33 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.google.common.base.Preconditions;
+import com.strategyobject.substrateclient.rpc.core.DecoderPair;
+import com.strategyobject.substrateclient.rpc.core.annotations.AutoRegister;
+import com.strategyobject.substrateclient.rpc.core.decoders.AbstractDecoder;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.val;
+
+import java.util.List;
+
+@AutoRegister(types = Pair.class)
+public class PairDecoder extends AbstractDecoder<Pair<?, ?>> {
+    @Override
+    protected Pair<?, ?> decodeNonNull(Object value, DecoderPair<?>[] decoders) {
+        val firstDecoder = decoders[0].getDecoderOrThrow();
+        val secondDecoder = decoders[1].getDecoderOrThrow();
+
+        val tuple = (List<?>) value;
+
+        return Pair.of(
+                firstDecoder.decode(tuple.get(0)),
+                secondDecoder.decode(tuple.get(1))
+        );
+    }
+
+    @Override
+    protected void checkArguments(Object value, DecoderPair<?>[] decoders) {
+        Preconditions.checkArgument(decoders != null && decoders.length == 2);
+        Preconditions.checkNotNull(decoders[0]);
+        Preconditions.checkNotNull(decoders[1]);
+    }
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageChangeSet.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageChangeSet.java
@@ -1,0 +1,20 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.strategyobject.substrateclient.rpc.core.annotations.RpcDecoder;
+import com.strategyobject.substrateclient.scale.annotations.Scale;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@RpcDecoder
+@NoArgsConstructor
+@Getter
+@Setter
+public class StorageChangeSet {
+    @Scale
+    private BlockHash block;
+    private List<Pair<StorageKey, StorageData>> changes;
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageData.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageData.java
@@ -1,0 +1,10 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "valueOf")
+public class StorageData {
+    private final byte[] data;
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageDataDecoder.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageDataDecoder.java
@@ -1,0 +1,14 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.rpc.core.DecoderPair;
+import com.strategyobject.substrateclient.rpc.core.annotations.AutoRegister;
+import com.strategyobject.substrateclient.rpc.core.decoders.AbstractDecoder;
+
+@AutoRegister(types = StorageData.class)
+public class StorageDataDecoder extends AbstractDecoder<StorageData> {
+    @Override
+    protected StorageData decodeNonNull(Object value, DecoderPair<?>[] decoders) {
+        return StorageData.valueOf(HexConverter.toBytes((String) value));
+    }
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKey.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKey.java
@@ -1,0 +1,10 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "valueOf")
+public class StorageKey {
+    private final byte[] data;
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKeyDecoder.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKeyDecoder.java
@@ -1,0 +1,14 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.rpc.core.DecoderPair;
+import com.strategyobject.substrateclient.rpc.core.annotations.AutoRegister;
+import com.strategyobject.substrateclient.rpc.core.decoders.AbstractDecoder;
+
+@AutoRegister(types = StorageKey.class)
+public class StorageKeyDecoder extends AbstractDecoder<StorageKey> {
+    @Override
+    protected StorageKey decodeNonNull(Object value, DecoderPair<?>[] decoders) {
+        return StorageKey.valueOf(HexConverter.toBytes((String) value));
+    }
+}

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKeyEncoder.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/StorageKeyEncoder.java
@@ -1,0 +1,18 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.google.common.base.Preconditions;
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.rpc.core.EncoderPair;
+import com.strategyobject.substrateclient.rpc.core.RpcEncoder;
+import com.strategyobject.substrateclient.rpc.core.annotations.AutoRegister;
+import lombok.NonNull;
+
+@AutoRegister(types = StorageKey.class)
+public class StorageKeyEncoder implements RpcEncoder<StorageKey> {
+    @Override
+    public Object encode(@NonNull StorageKey source, EncoderPair<?>... encoders) {
+        Preconditions.checkArgument(encoders == null || encoders.length == 0);
+
+        return HexConverter.toHex(source.getData());
+    }
+}

--- a/scale/src/main/java/com/strategyobject/substrateclient/scale/ScaleRegistryHelper.java
+++ b/scale/src/main/java/com/strategyobject/substrateclient/scale/ScaleRegistryHelper.java
@@ -1,0 +1,32 @@
+package com.strategyobject.substrateclient.scale;
+
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import lombok.val;
+
+public final class ScaleRegistryHelper {
+    private ScaleRegistryHelper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> ScaleReader<T> resolveAndInjectOrNull(Class<T> clazz, ScaleReader<?>... dependencies) {
+        val target = (ScaleReader<T>) ScaleReaderRegistry.getInstance().resolve(clazz);
+
+        if (target == null) {
+            return null;
+        }
+
+        return target.inject(dependencies);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> ScaleWriter<T> resolveAndInjectOrNull(Class<T> clazz, ScaleWriter<?>... dependencies) {
+        val target = (ScaleWriter<T>) ScaleWriterRegistry.getInstance().resolve(clazz);
+
+        if (target == null) {
+            return null;
+        }
+
+        return target.inject(dependencies);
+    }
+}

--- a/types/src/main/java/com/strategyobject/substrateclient/types/tuples/Pair.java
+++ b/types/src/main/java/com/strategyobject/substrateclient/types/tuples/Pair.java
@@ -1,0 +1,11 @@
+package com.strategyobject.substrateclient.types.tuples;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public final class Pair<F, S> {
+    private final F value0;
+    private final S value1;
+}


### PR DESCRIPTION
There are added methods `getKeys`, `getStorage`, `queryStorageAt` to section `state`.
Added corresponding entities: `StorageKey`, `StorageData`, `StorageChangeSet`, `Pair`.
Implemented encoders/decoders: `StorageKeyEncoder`, `StorageKeyDecoder`, `StorageDataDecoder`, `PairDecoder`.
Fixed bugs of code generation RpcEncoder/RpcDecoder when it contains generic fields.