### PR TITLE
Abstractions and API for querying to storages

### DIFF
--- a/api/src/main/java/com/strategyobject/substrateclient/api/Api.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/Api.java
@@ -3,5 +3,5 @@ package com.strategyobject.substrateclient.api;
 import com.strategyobject.substrateclient.rpc.Rpc;
 
 public interface Api {
-    Rpc getRpc();
+    Rpc rpc();
 }

--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -2,5 +2,4 @@ dependencies {
     implementation project(':transport')
     implementation project(':rpc:rpc-sections')
     implementation project(':rpc:rpc-core')
-    implementation project(':rpc:rpc-codegen')
 }

--- a/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/sections/RpcSectionFactoryTest.java
+++ b/rpc/rpc-codegen/src/test/java/com/strategyobject/substrateclient/rpc/codegen/sections/RpcSectionFactoryTest.java
@@ -1,6 +1,8 @@
 package com.strategyobject.substrateclient.rpc.codegen.sections;
 
 import com.strategyobject.substrateclient.rpc.codegen.substitutes.TestSection;
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
 import com.strategyobject.substrateclient.transport.ProviderInterface;
 import com.strategyobject.substrateclient.transport.RpcBoolean;
 import com.strategyobject.substrateclient.transport.RpcObject;
@@ -26,8 +28,7 @@ public class RpcSectionFactoryTest {
         when(provider.send(anyString(), anyList()))
                 .thenReturn(sendFuture);
 
-        val factory = new RpcGeneratedSectionFactory();
-        val rpcSection = factory.create(TestSection.class, provider);
+        val rpcSection = RpcGeneratedSectionFactory.create(TestSection.class, provider);
 
         val actual = rpcSection.doNothing("some").get();
 

--- a/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcGeneratedSectionFactory.java
+++ b/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcGeneratedSectionFactory.java
@@ -1,4 +1,4 @@
-package com.strategyobject.substrateclient.rpc.codegen.sections;
+package com.strategyobject.substrateclient.rpc.core;
 
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcInterface;
 import com.strategyobject.substrateclient.transport.ProviderInterface;
@@ -7,11 +7,14 @@ import lombok.val;
 
 import java.lang.reflect.InvocationTargetException;
 
-import static com.strategyobject.substrateclient.rpc.codegen.sections.Constants.CLASS_NAME_TEMPLATE;
-
 public class RpcGeneratedSectionFactory {
-    public <T> T create(@NonNull Class<T> interfaceClass,
-                        @NonNull ProviderInterface provider) throws RpcInterfaceInitializationException {
+    private static final String CLASS_NAME_TEMPLATE = "%sImpl";
+
+    private RpcGeneratedSectionFactory() {
+    }
+
+    public static <T> T create(@NonNull Class<T> interfaceClass,
+                               @NonNull ProviderInterface provider) throws RpcInterfaceInitializationException {
         if (interfaceClass.getDeclaredAnnotationsByType(RpcInterface.class).length == 0) {
             throw new IllegalArgumentException(
                     String.format("`%s` can't be constructed because isn't annotated with `@%s`.",

--- a/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcInterfaceInitializationException.java
+++ b/rpc/rpc-core/src/main/java/com/strategyobject/substrateclient/rpc/core/RpcInterfaceInitializationException.java
@@ -1,4 +1,4 @@
-package com.strategyobject.substrateclient.rpc.codegen.sections;
+package com.strategyobject.substrateclient.rpc.core;
 
 public class RpcInterfaceInitializationException extends Exception {
     public RpcInterfaceInitializationException(Throwable ex) {

--- a/rpc/rpc-sections/build.gradle
+++ b/rpc/rpc-sections/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     implementation project(':rpc:rpc-types')
     implementation project(':scale')
 
-    testImplementation project(':rpc:rpc-codegen')
     testImplementation project(':tests')
     testCompileOnly project(':rpc:rpc-core')
     testCompileOnly project(':common')

--- a/rpc/rpc-sections/src/main/java/com/strategyobject/substrateclient/rpc/sections/State.java
+++ b/rpc/rpc-sections/src/main/java/com/strategyobject/substrateclient/rpc/sections/State.java
@@ -2,11 +2,14 @@ package com.strategyobject.substrateclient.rpc.sections;
 
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcCall;
 import com.strategyobject.substrateclient.rpc.core.annotations.RpcInterface;
+import com.strategyobject.substrateclient.rpc.core.annotations.RpcSubscription;
 import com.strategyobject.substrateclient.rpc.types.*;
 import com.strategyobject.substrateclient.scale.annotations.Scale;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 @RpcInterface(section = "state")
 public interface State {
@@ -20,9 +23,56 @@ public interface State {
     @RpcCall(method = "getKeys")
     CompletableFuture<List<StorageKey>> getKeys(StorageKey key);
 
+    @RpcCall(method = "getKeys")
+    CompletableFuture<List<StorageKey>> getKeys(StorageKey key, @Scale BlockHash at);
+
+    @RpcCall(method = "getKeysPaged")
+    CompletableFuture<List<StorageKey>> getKeysPaged(StorageKey key, int count);
+
+    @RpcCall(method = "getKeysPaged")
+    CompletableFuture<List<StorageKey>> getKeysPaged(StorageKey key, int count, StorageKey startKey);
+
+    @RpcCall(method = "getKeysPaged")
+    CompletableFuture<List<StorageKey>> getKeysPaged(StorageKey key,
+                                                     int count,
+                                                     StorageKey startKey,
+                                                     @Scale BlockHash at);
+
     @RpcCall(method = "getStorage")
     CompletableFuture<StorageData> getStorage(StorageKey key);
 
+    @RpcCall(method = "getStorage")
+    CompletableFuture<StorageData> getStorage(StorageKey key, @Scale BlockHash at);
+
+    @RpcCall(method = "getStorageHash")
+    @Scale
+    CompletableFuture<Hash> getStorageHash(StorageKey key);
+
+    @RpcCall(method = "getStorageHash")
+    @Scale
+    CompletableFuture<Hash> getStorageHash(StorageKey key, @Scale BlockHash at);
+
+    @RpcCall(method = "getStorageSize")
+    CompletableFuture<Long> getStorageSize(StorageKey key);
+
+    @RpcCall(method = "getStorageSize")
+    CompletableFuture<Long> getStorageSize(StorageKey key, @Scale BlockHash at);
+
+    @RpcCall(method = "queryStorage")
+    CompletableFuture<List<StorageChangeSet>> queryStorage(List<StorageKey> keys, @Scale BlockHash fromBlock);
+
+    @RpcCall(method = "queryStorage")
+    CompletableFuture<List<StorageChangeSet>> queryStorage(List<StorageKey> keys,
+                                                           @Scale BlockHash fromBlock,
+                                                           @Scale BlockHash toBlock);
+
     @RpcCall(method = "queryStorageAt")
     CompletableFuture<List<StorageChangeSet>> queryStorageAt(List<StorageKey> keys);
+
+    @RpcCall(method = "queryStorageAt")
+    CompletableFuture<List<StorageChangeSet>> queryStorageAt(List<StorageKey> keys, @Scale BlockHash at);
+
+    @RpcSubscription(type = "storage", subscribeMethod = "subscribeStorage", unsubscribeMethod = "unsubscribeStorage")
+    CompletableFuture<Supplier<CompletableFuture<Boolean>>> subscribeStorage(List<StorageKey> keys,
+                                                                             BiConsumer<Exception, StorageChangeSet> callback);
 }

--- a/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/AuthorTests.java
+++ b/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/AuthorTests.java
@@ -2,8 +2,8 @@ package com.strategyobject.substrateclient.rpc.sections;
 
 import com.strategyobject.substrateclient.common.utils.HexConverter;
 import com.strategyobject.substrateclient.crypto.KeyRing;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcGeneratedSectionFactory;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcInterfaceInitializationException;
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
 import com.strategyobject.substrateclient.rpc.sections.substitutes.BalanceTransfer;
 import com.strategyobject.substrateclient.rpc.types.*;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
@@ -58,8 +58,7 @@ public class AuthorTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            Author rpcSection = sectionFactory.create(Author.class, wsProvider);
+            Author rpcSection = RpcGeneratedSectionFactory.create(Author.class, wsProvider);
 
             val publicKey = PublicKey.fromBytes(
                     HexConverter.toBytes("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"));
@@ -83,8 +82,7 @@ public class AuthorTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            Author rpcSection = sectionFactory.create(Author.class, wsProvider);
+            Author rpcSection = RpcGeneratedSectionFactory.create(Author.class, wsProvider);
 
             assertDoesNotThrow(() -> rpcSection.insertKey("aura",
                             "alice",
@@ -102,11 +100,10 @@ public class AuthorTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            Chain chainSection = sectionFactory.create(Chain.class, wsProvider);
+            Chain chainSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val genesis = chainSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
-            Author authorSection = sectionFactory.create(Author.class, wsProvider);
+            Author authorSection = RpcGeneratedSectionFactory.create(Author.class, wsProvider);
 
             assertDoesNotThrow(() -> authorSection.submitExtrinsic(createBalanceTransferExtrinsic(genesis, NONCE.getAndIncrement()))
                     .get(WAIT_TIMEOUT, TimeUnit.SECONDS));
@@ -121,11 +118,10 @@ public class AuthorTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            Chain chainSection = sectionFactory.create(Chain.class, wsProvider);
+            Chain chainSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val genesis = chainSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
-            Author authorSection = sectionFactory.create(Author.class, wsProvider);
+            Author authorSection = RpcGeneratedSectionFactory.create(Author.class, wsProvider);
 
             val updateCount = new AtomicInteger(0);
             val status = new AtomicReference<ExtrinsicStatus>();

--- a/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/ChainTests.java
+++ b/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/ChainTests.java
@@ -1,7 +1,7 @@
 package com.strategyobject.substrateclient.rpc.sections;
 
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcGeneratedSectionFactory;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcInterfaceInitializationException;
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
 import com.strategyobject.substrateclient.rpc.types.BlockHash;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
@@ -40,8 +40,7 @@ public class ChainTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            val rpcSection = sectionFactory.create(Chain.class, wsProvider);
+            val rpcSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val result = rpcSection.getFinalizedHead().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
@@ -57,8 +56,7 @@ public class ChainTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            val rpcSection = sectionFactory.create(Chain.class, wsProvider);
+            val rpcSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val blockCount = new AtomicInteger(0);
             val blockHash = new AtomicReference<BlockHash>(null);
@@ -91,8 +89,7 @@ public class ChainTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            val rpcSection = sectionFactory.create(Chain.class, wsProvider);
+            val rpcSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val result = rpcSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
@@ -108,8 +105,7 @@ public class ChainTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            Chain rpcSection = sectionFactory.create(Chain.class, wsProvider);
+            Chain rpcSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
 
             val height = new AtomicInteger(0);
             rpcSection.subscribeNewHeads((e, header) -> {

--- a/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/StateTests.java
+++ b/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/StateTests.java
@@ -1,8 +1,8 @@
 package com.strategyobject.substrateclient.rpc.sections;
 
 import com.strategyobject.substrateclient.common.utils.HexConverter;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcGeneratedSectionFactory;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcInterfaceInitializationException;
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
 import com.strategyobject.substrateclient.rpc.types.StorageKey;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
@@ -37,8 +37,7 @@ public class StateTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             assertDoesNotThrow(() -> {
                 rpcSection.getRuntimeVersion().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -54,8 +53,7 @@ public class StateTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             assertDoesNotThrow(() -> {
                 rpcSection.getMetadata().get(WAIT_TIMEOUT * 10, TimeUnit.SECONDS);
@@ -71,8 +69,7 @@ public class StateTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
             // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
@@ -91,8 +88,7 @@ public class StateTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
             // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
@@ -112,8 +108,7 @@ public class StateTests {
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             val emptyKey = new byte[32];
             val storageData = rpcSection.getStorage(StorageKey.valueOf(emptyKey)).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -123,15 +118,124 @@ public class StateTests {
     }
 
     @Test
-    void getStorageAt() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+    void getStorageAtBlock() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
         try (WsProvider wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
                 .disableAutoConnect()
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            State rpcSection = sectionFactory.create(State.class, wsProvider);
+            val chainSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
+            val blockHash = chainSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
+
+            // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
+            // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
+            val key = "0xc2261276cc9d1f8598ea4b6a74b15c2f308ce9615de0775a82f8a94dc3d285a1"; // TODO implement and use `xxhash`
+            val storageData = rpcSection.getStorage(
+                    StorageKey.valueOf(HexConverter.toBytes(key)),
+                    blockHash).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertNotNull(storageData);
+            assertTrue(storageData.getData().length > 0);
+        }
+    }
+
+    @Test
+    void getStorageHash() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+        try (WsProvider wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build()) {
+            wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
+
+            // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
+            // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
+            val key = "0xc2261276cc9d1f8598ea4b6a74b15c2f308ce9615de0775a82f8a94dc3d285a1"; // TODO implement and use `xxhash`
+            val hash = rpcSection.getStorageHash(StorageKey.valueOf(HexConverter.toBytes(key))).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertNotNull(hash);
+            assertTrue(hash.getData().length > 0);
+        }
+    }
+
+    @Test
+    void getStorageHashAt() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+        try (WsProvider wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build()) {
+            wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            val chainSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
+            val blockHash = chainSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
+
+            // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
+            // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
+            val key = "0xc2261276cc9d1f8598ea4b6a74b15c2f308ce9615de0775a82f8a94dc3d285a1"; // TODO implement and use `xxhash`
+            val hash = rpcSection.getStorageHash(
+                    StorageKey.valueOf(HexConverter.toBytes(key)),
+                    blockHash).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertNotNull(hash);
+            assertTrue(hash.getData().length > 0);
+        }
+    }
+
+    @Test
+    void getStorageSize() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+        try (WsProvider wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build()) {
+            wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
+
+            // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
+            // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
+            val key = "0xc2261276cc9d1f8598ea4b6a74b15c2f308ce9615de0775a82f8a94dc3d285a1"; // TODO implement and use `xxhash`
+            val size = rpcSection.getStorageSize(StorageKey.valueOf(HexConverter.toBytes(key))).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertEquals(1, size);
+        }
+    }
+
+    @Test
+    void getStorageSizeAt() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+        try (WsProvider wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build()) {
+            wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            val chainSection = RpcGeneratedSectionFactory.create(Chain.class, wsProvider);
+            val blockHash = chainSection.getBlockHash(0).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
+
+            // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
+            // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1
+            val key = "0xc2261276cc9d1f8598ea4b6a74b15c2f308ce9615de0775a82f8a94dc3d285a1"; // TODO implement and use `xxhash`
+            val size = rpcSection.getStorageSize(
+                    StorageKey.valueOf(HexConverter.toBytes(key)),
+                    blockHash).get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertEquals(1, size);
+        }
+    }
+
+    @Test
+    void queryStorageAt() throws ExecutionException, InterruptedException, TimeoutException, RpcInterfaceInitializationException {
+        try (WsProvider wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build()) {
+            wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            State rpcSection = RpcGeneratedSectionFactory.create(State.class, wsProvider);
 
             // xxhash128("Balances") = 0xc2261276cc9d1f8598ea4b6a74b15c2f
             // xxhash128("StorageVersion") = 0x308ce9615de0775a82f8a94dc3d285a1

--- a/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/SystemTests.java
+++ b/rpc/rpc-sections/src/test/java/com/strategyobject/substrateclient/rpc/sections/SystemTests.java
@@ -1,8 +1,8 @@
 package com.strategyobject.substrateclient.rpc.sections;
 
 import com.strategyobject.substrateclient.common.utils.HexConverter;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcGeneratedSectionFactory;
-import com.strategyobject.substrateclient.rpc.codegen.sections.RpcInterfaceInitializationException;
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
 import com.strategyobject.substrateclient.rpc.types.AccountId;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
@@ -32,8 +32,7 @@ public class SystemTests {
         try (WsProvider wsProvider = WsProvider.builder().setEndpoint(substrate.getWsAddress()).disableAutoConnect().build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 
-            val sectionFactory = new RpcGeneratedSectionFactory();
-            System rpcSection = sectionFactory.create(System.class, wsProvider);
+            System rpcSection = RpcGeneratedSectionFactory.create(System.class, wsProvider);
 
             val alicePublicKey = HexConverter.toBytes("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
             val result = rpcSection.accountNextIndex(AccountId.fromBytes(alicePublicKey))

--- a/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/AccountIdReader.java
+++ b/rpc/rpc-types/src/main/java/com/strategyobject/substrateclient/rpc/types/AccountIdReader.java
@@ -1,0 +1,21 @@
+package com.strategyobject.substrateclient.rpc.types;
+
+import com.google.common.base.Preconditions;
+import com.strategyobject.substrateclient.common.io.Streamer;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.annotations.AutoRegister;
+import com.strategyobject.substrateclient.types.Size;
+import lombok.NonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@AutoRegister(types = AccountId.class)
+public class AccountIdReader implements ScaleReader<AccountId> {
+    @Override
+    public AccountId read(@NonNull InputStream stream, ScaleReader<?>... readers) throws IOException {
+        Preconditions.checkArgument(readers == null || readers.length == 0);
+
+        return AccountId.fromBytes(Streamer.readBytes(Size.of32.getValue(), stream));
+    }
+}

--- a/rpc/src/main/java/com/strategyobject/substrateclient/rpc/Rpc.java
+++ b/rpc/src/main/java/com/strategyobject/substrateclient/rpc/Rpc.java
@@ -6,11 +6,11 @@ import com.strategyobject.substrateclient.rpc.sections.State;
 import com.strategyobject.substrateclient.rpc.sections.System;
 
 public interface Rpc {
-    Author getAuthor();
+    Author author();
 
-    Chain getChain();
+    Chain chain();
 
-    State getState();
+    State state();
 
-    System getSystem();
+    System system();
 }

--- a/rpc/src/main/java/com/strategyobject/substrateclient/rpc/RpcImpl.java
+++ b/rpc/src/main/java/com/strategyobject/substrateclient/rpc/RpcImpl.java
@@ -1,0 +1,58 @@
+package com.strategyobject.substrateclient.rpc;
+
+import com.strategyobject.substrateclient.rpc.core.RpcGeneratedSectionFactory;
+import com.strategyobject.substrateclient.rpc.core.RpcInterfaceInitializationException;
+import com.strategyobject.substrateclient.rpc.sections.Author;
+import com.strategyobject.substrateclient.rpc.sections.Chain;
+import com.strategyobject.substrateclient.rpc.sections.State;
+import com.strategyobject.substrateclient.rpc.sections.System;
+import com.strategyobject.substrateclient.transport.ProviderInterface;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RpcImpl implements Rpc, AutoCloseable {
+    private final ProviderInterface providerInterface;
+
+    @Override
+    public Author author() {
+        try {
+            return RpcGeneratedSectionFactory.create(Author.class, providerInterface);
+        } catch (RpcInterfaceInitializationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Chain chain() {
+        try {
+            return RpcGeneratedSectionFactory.create(Chain.class, providerInterface);
+        } catch (RpcInterfaceInitializationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public State state() {
+        try {
+            return RpcGeneratedSectionFactory.create(State.class, providerInterface);
+        } catch (RpcInterfaceInitializationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public System system() {
+        try {
+            return RpcGeneratedSectionFactory.create(System.class, providerInterface);
+        } catch (RpcInterfaceInitializationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (providerInterface instanceof AutoCloseable) {
+            ((AutoCloseable) providerInterface).close();
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,5 @@ include 'scale:scale-codegen'
 include 'tests'
 include 'transport'
 include 'types'
+include 'storage'
+

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -1,0 +1,19 @@
+dependencies {
+    implementation project(':common')
+    implementation project(':scale')
+    implementation project(':crypto')
+    implementation project(':types')
+    implementation project(':rpc')
+    implementation project(':rpc:rpc-types')
+    implementation project(':rpc:rpc-sections')
+
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    implementation 'net.openhft:zero-allocation-hashing:0.15'
+
+    testImplementation project(':tests')
+    testCompileOnly project(':transport')
+
+    testImplementation 'org.testcontainers:testcontainers:1.16.3'
+    testImplementation 'org.testcontainers:junit-jupiter:1.16.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.6'
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/Arg.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/Arg.java
@@ -1,0 +1,29 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Represent the argument of multi query to storage.
+ * It contains the list of keys which are required for the specific storage.
+ */
+public class Arg {
+    /**
+     * List of keys.
+     */
+    @Getter
+    private final Object[] list;
+
+    private Arg(Object[] list) {
+        this.list = list;
+    }
+
+    /**
+     * Creates a new Arg.
+     * @param keys any number of keys.
+     * @return a new Arg with given keys.
+     */
+    public static Arg of(@NonNull Object... keys) {
+        return new Arg(keys);
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/Blake2B128Concat.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/Blake2B128Concat.java
@@ -1,0 +1,60 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+import lombok.val;
+import org.bouncycastle.crypto.digests.Blake2bDigest;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Blake2 128 Concat hash algorithm.
+ * This algorithm is cryptographic and transparent.
+ * It's used to generate storage map's key.
+ */
+public class Blake2B128Concat implements KeyHashingAlgorithm {
+    private static final int BLAKE_128_HASH_SIZE = 16;
+    private static volatile Blake2B128Concat instance;
+
+    private static byte[] blake2_128(byte[] value) {
+        val digest = new Blake2bDigest(128);
+        digest.update(value, 0, value.length);
+
+        val result = new byte[digest.getDigestSize()];
+        digest.doFinal(result, 0);
+        return result;
+    }
+
+    /**
+     * @return the instance of the algorithm.
+     */
+    public static Blake2B128Concat getInstance() {
+        if (instance == null) {
+            synchronized (Blake2B128Concat.class) {
+                if (instance == null) {
+                    instance = new Blake2B128Concat();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * @param encodedKey binary data that represents the encoded key.
+     * @return hash for given key.
+     */
+    @Override
+    public byte[] getHash(byte @NonNull [] encodedKey) {
+        return ByteBuffer.allocate(BLAKE_128_HASH_SIZE + encodedKey.length)
+                .put(blake2_128(encodedKey))
+                .put(encodedKey)
+                .array();
+    }
+
+    /**
+     * @return size of the algorithm.
+     */
+    @Override
+    public int hashSize() {
+        return BLAKE_128_HASH_SIZE;
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/DiverseKeyValueCollection.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/DiverseKeyValueCollection.java
@@ -1,0 +1,94 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.base.Preconditions;
+import com.strategyobject.substrateclient.rpc.types.StorageData;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+/**
+ * Collection that contains entries from various storage types.
+ */
+public class DiverseKeyValueCollection implements KeyValueCollection<Object> {
+    private final List<ScaleReader<Object>> valueReaders;
+    private final List<Pair<StorageKey, StorageData>> pairs;
+    private final List<Function<StorageKey, List<Object>>> keyExtractors;
+
+    private DiverseKeyValueCollection(List<Pair<StorageKey, StorageData>> pairs,
+                                      List<ScaleReader<Object>> valueReaders,
+                                      List<Function<StorageKey, List<Object>>> keyExtractors) {
+
+        Preconditions.checkArgument(pairs.size() == valueReaders.size(),
+                "Number of value readers doesn't match number of pairs.");
+
+        Preconditions.checkArgument(pairs.size() == keyExtractors.size(),
+                "Number of extractors doesn't match number of pairs.");
+
+        this.valueReaders = valueReaders;
+        this.pairs = pairs;
+        this.keyExtractors = keyExtractors;
+    }
+
+    /**
+     * @param pairs list of pairs of storage's keys and data.
+     * @param valueReaders list of scale readers which read the value from StorageData
+     *                     of the appropriate pair.
+     * @param keyExtractors list of functions which extract keys
+     *                      from StorageKey of the appropriate pair.
+     * @return certain collection.
+     */
+    public static KeyValueCollection<Object> with(@NonNull List<Pair<StorageKey, StorageData>> pairs,
+                                                  List<ScaleReader<Object>> valueReaders,
+                                                  @NonNull List<Function<StorageKey, List<Object>>> keyExtractors) {
+        return new DiverseKeyValueCollection(pairs, valueReaders, keyExtractors);
+    }
+
+    /**
+     * @return iterator of entries.
+     */
+    @Override
+    public Iterator<Entry<Object>> iterator() {
+        return new Iterator<Entry<Object>>() {
+            private final Iterator<Pair<StorageKey, StorageData>> underlying = pairs.iterator();
+            private final Iterator<ScaleReader<Object>> readers = valueReaders.iterator();
+            private final Iterator<Function<StorageKey, List<Object>>> extractors = keyExtractors.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return underlying.hasNext();
+            }
+
+            @Override
+            public Entry<Object> next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                val pair = underlying.next();
+
+                return consumer -> {
+                    try {
+                        val nextReader = readers.next();
+                        val value = pair.getValue1() == null ?
+                                null :
+                                nextReader.read(new ByteArrayInputStream(pair.getValue1().getData()));
+                        val keys = extractors.next().apply(pair.getValue0());
+
+                        consumer.accept(value, keys);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+            }
+        };
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/Entry.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/Entry.java
@@ -1,0 +1,12 @@
+package com.strategyobject.substrateclient.storage;
+
+/**
+ * Entry of keys and value of storage.
+ * @param <V> the type of the value.
+ */
+public interface Entry<V> {
+    /**
+     * @param consumer that consumes value and keys of the entry.
+     */
+    void consume(KeyValueConsumer<V> consumer);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/HomogeneousKeyValueCollection.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/HomogeneousKeyValueCollection.java
@@ -1,0 +1,63 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.types.StorageData;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+/**
+ * Collection that contains only entries from a particular storage.
+ */
+@RequiredArgsConstructor(staticName = "with")
+class HomogeneousKeyValueCollection<V> implements KeyValueCollection<V> {
+    private final @NonNull List<Pair<StorageKey, StorageData>> pairs;
+    private final @NonNull ScaleReader<V> valueReader;
+    private final @NonNull Function<StorageKey, List<Object>> keyExtractor;
+
+    /**
+     * @return iterator of entries.
+     */
+    @Override
+    public Iterator<Entry<V>> iterator() {
+        return new Iterator<Entry<V>>() {
+            private final Iterator<Pair<StorageKey, StorageData>> underlying = pairs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return underlying.hasNext();
+            }
+
+            @Override
+            public Entry<V> next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+
+                val pair = underlying.next();
+
+                return consumer -> {
+                    try {
+                        val value = pair.getValue1() == null ?
+                                null :
+                                valueReader.read(new ByteArrayInputStream(pair.getValue1().getData()));
+                        val keys = keyExtractor.apply(pair.getValue0());
+
+                        consumer.accept(value, keys);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+            }
+        };
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/Identity.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/Identity.java
@@ -1,0 +1,45 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+
+/**
+ * Identity hash algorithm.
+ * This algorithm doesn't produce a hash and returns a key as is.
+ * Supposed the algorithm will be used only for keys of fixed length.
+ * This algorithm is non-cryptographic and transparent.
+ * It's used to generate storage map's key.
+ */
+public class Identity implements KeyHashingAlgorithm {
+    private static volatile Identity instance;
+
+    /**
+     * @return the instance of the algorithm.
+     */
+    public static Identity getInstance() {
+        if (instance == null) {
+            synchronized (Identity.class) {
+                if (instance == null) {
+                    instance = new Identity();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * @param encodedKey binary data that represents the encoded key.
+     * @return the given key as is. The length of the key must have fixed size.
+     */
+    @Override
+    public byte[] getHash(byte @NonNull [] encodedKey) {
+        return encodedKey;
+    }
+
+    /**
+     * @return size of the algorithm. In that case it's zero.
+     */
+    @Override
+    public int hashSize() {
+        return 0;
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyCollection.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyCollection.java
@@ -1,0 +1,25 @@
+package com.strategyobject.substrateclient.storage;
+
+import java.util.Iterator;
+
+/**
+ * Collection of keys of storage(s).
+ * @param <V> the type of the value.
+ */
+public interface KeyCollection<V> {
+    /**
+     * @return number of keys.
+     */
+    int size();
+
+    /**
+     * @return the multi query that allows to make single request to storages with given keys.
+     */
+    MultiQuery<V> multi();
+
+    /**
+     * @return the queryable key that allows to request value.
+     * The queryable key can also be joined to other keys for forming a multi query.
+     */
+    Iterator<QueryableKey<V>> iterator();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyCollectionImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyCollectionImpl.java
@@ -1,0 +1,67 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @param <V> the type of the value.
+ */
+@RequiredArgsConstructor(staticName = "with")
+public class KeyCollectionImpl<V> implements KeyCollection<V> {
+    private final @NonNull Rpc rpc;
+    private final @NonNull List<StorageKey> storageKeys;
+    private final @NonNull ScaleReader<V> valueReader;
+    private final @NonNull Function<StorageKey, List<Object>> keyExtractor;
+
+    @Override
+    public int size() {
+        return storageKeys.size();
+    }
+
+    @Override
+    public MultiQuery<V> multi() {
+        return () -> rpc
+                .state()
+                .queryStorageAt(storageKeys)
+                .thenApplyAsync(changeSets -> HomogeneousKeyValueCollection.with(
+                        changeSets.stream()
+                                .flatMap(set -> set.getChanges().stream())
+                                .collect(Collectors.toList()),
+                        valueReader,
+                        keyExtractor
+                ));
+    }
+
+    @Override
+    public Iterator<QueryableKey<V>> iterator() {
+        return new Iterator<QueryableKey<V>>() {
+            private final Iterator<StorageKey> underlying = storageKeys.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return underlying.hasNext();
+            }
+
+            @Override
+            public QueryableKey<V> next() {
+                if (hasNext()) {
+                    val key = underlying.next();
+
+                    return QueryableKeyImpl.with(rpc, key, valueReader, keyExtractor);
+                }
+
+                throw new NoSuchElementException();
+            }
+        };
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyConsumer.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyConsumer.java
@@ -1,0 +1,17 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * Represents an operation that accepts list of keys and returns no result.
+ */
+@FunctionalInterface
+public interface KeyConsumer {
+    /**
+     * Performs this operation on the given arguments.
+     * @param keys the list of keys of the storage's entry.
+     */
+    void accept(@NonNull List<Object> keys);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyHasher.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyHasher.java
@@ -1,0 +1,50 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Represents entity which is responsible for hashing key (using a particular algorithm)
+ * and extracting the one from hashed data.
+ * @param <T> the type of the key.
+ */
+@RequiredArgsConstructor(staticName = "with")
+public class KeyHasher<T> {
+    private final @NonNull ScaleWriter<T> keyWriter;
+    private final @NonNull ScaleReader<T> keyReader;
+    private final @NonNull KeyHashingAlgorithm algorithm;
+
+    /**
+     * @param key one of the keys of the storage.
+     * @return hash of the key.
+     * @throws IOException when writing the key to scale fails.
+     */
+    public byte[] getHash(T key) throws IOException {
+        val buf = new ByteArrayOutputStream();
+        keyWriter.write(key, buf);
+
+        return algorithm.getHash(buf.toByteArray());
+    }
+
+    /**
+     * @param storageKeySuffix binary data that starts from the hashed key
+     *                         and can contain the other hashed keys of the storage's entry.
+     * @return key.
+     * @throws IOException when reading the key from scale fails.
+     */
+    public T extractKey(@NonNull InputStream storageKeySuffix) throws IOException {
+        val skip = storageKeySuffix.skip(algorithm.hashSize());
+        if (skip != algorithm.hashSize()) {
+            throw new RuntimeException("Stream couldn't skip the hash.");
+        }
+
+        return keyReader.read(storageKeySuffix);
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyHashingAlgorithm.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyHashingAlgorithm.java
@@ -1,0 +1,23 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+
+/**
+ * An algorithm that's used to generate storage map's key.
+ * As a general rule it should be a transparent algorithm since
+ * non-transparent hashers are deprecated in Substrate.
+ */
+public interface KeyHashingAlgorithm {
+    /**
+     * @param encodedKey binary data that represents the encoded key.
+     * @return the hash of the key produced by the algorithm.
+     */
+    byte[] getHash(byte @NonNull [] encodedKey);
+
+    /**
+     * @return purely the size of the certain hashing algorithm.
+     * Supposed that algorithm is transparent and the method returns
+     * exceptionally the hash size without considering any concatenated parts.
+     */
+    int hashSize();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyValueCollection.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyValueCollection.java
@@ -1,0 +1,14 @@
+package com.strategyobject.substrateclient.storage;
+
+import java.util.Iterator;
+
+/**
+ * Collection of storage's entries. Each entry contains keys and a value.
+ * @param <V> the type of the value.
+ */
+public interface KeyValueCollection<V> {
+    /**
+     * @return iterator of entries.
+     */
+    Iterator<Entry<V>> iterator();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyValueConsumer.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/KeyValueConsumer.java
@@ -1,0 +1,19 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * Represents an operation that accepts the value and the list of keys and returns no result.
+ * @param <V> the type of the value.
+ */
+@FunctionalInterface
+public interface KeyValueConsumer<V> {
+    /**
+     * Performs this operation on the given arguments.
+     * @param value the value of the storage's entry.
+     * @param keys the list of keys of the storage's entry.
+     */
+    void accept(V value, @NonNull List<Object> keys);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/MultiQuery.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/MultiQuery.java
@@ -1,0 +1,15 @@
+package com.strategyobject.substrateclient.storage;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Represents a query to storage(s).
+ * It allows to request multiple data within a single query.
+ * @param <V> the type of the value.
+ */
+public interface MultiQuery<V> {
+    /**
+     * @return key-value collection of entries.
+     */
+    CompletableFuture<KeyValueCollection<V>> execute();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/PagedKeyIterator.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/PagedKeyIterator.java
@@ -1,0 +1,29 @@
+package com.strategyobject.substrateclient.storage;
+
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * An iterator of key collection.
+ * Each element in the sequence contains a key collection with size
+ * equal to the page's size or smaller in case of the last page and the total number
+ * isn't multiple of tbe page's size.
+ * @param <V> the type of the value.
+ */
+public interface PagedKeyIterator<V> {
+    /**
+     * @return number of the current page.
+     */
+    int number();
+
+    /**
+     * Requests the next page and returns the flag of existence of such page.
+     * @return true if the next page exists.
+     */
+    CompletableFuture<Boolean> moveNext();
+
+    /**
+     * @return the current page of keys.
+     */
+    KeyCollection<V> current();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/PagedKeyValueIterator.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/PagedKeyValueIterator.java
@@ -1,0 +1,28 @@
+package com.strategyobject.substrateclient.storage;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An iterator of key-value collection.
+ * Each element in the sequence contains a key-value collection with size
+ * equal to the page's size or smaller in case of the last page and the total number
+ * isn't multiple of tbe page's size.
+ * @param <V> the type of the value.
+ */
+public interface PagedKeyValueIterator<V> {
+    /**
+     * @return number of the current page.
+     */
+    int number();
+
+    /**
+     * Requests the next page and returns the flag of existence of such page.
+     * @return true if the next page exists.
+     */
+    CompletableFuture<Boolean> moveNext();
+
+    /**
+     * @return the current page of key-values.
+     */
+    KeyValueCollection<V> current();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/QueryableKey.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/QueryableKey.java
@@ -1,0 +1,48 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Represents a query to the storage.
+ * Can be executed or joined to other queries.
+ * @param <V> the type of the value.
+ */
+public interface QueryableKey<V> {
+    /**
+     * @return value.
+     */
+    CompletableFuture<V> execute();
+
+    /**
+     * @return StorageKey produced from given key.
+     */
+    StorageKey getKey();
+
+    /**
+     * @return reader for the value of the storage's entry.
+     */
+    ScaleReader<V> getValueReader();
+
+    /**
+     * @param consumer that consumes keys of the entry.
+     */
+    void consume(@NonNull KeyConsumer consumer);
+
+    /**
+     * @param others keys to be joined.
+     * @return the multi query that allows to make single request to storages with given keys.
+     */
+    MultiQuery<Object> join(@NonNull QueryableKey<?>... others);
+
+    /**
+     * @param fullKey StorageKey that contains pallet and storage names and all keys
+     *                of the storage's entry.
+     * @return all keys of the entry.
+     */
+    List<Object> extractKeys(@NonNull StorageKey fullKey);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/QueryableKeyImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/QueryableKeyImpl.java
@@ -1,0 +1,106 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @param <V> the type of the value.
+ */
+@RequiredArgsConstructor(staticName = "with")
+class QueryableKeyImpl<V> implements QueryableKey<V> {
+    private final Rpc rpc;
+    private final StorageKey key;
+    private final ScaleReader<V> valueReader;
+    private final Function<StorageKey, List<Object>> keyExtractor;
+
+    @Override
+    public CompletableFuture<V> execute() {
+        return rpc
+                .state()
+                .getStorage(key)
+                .thenApplyAsync(d -> {
+                    if (d == null) {
+                        return null;
+                    }
+
+                    try {
+                        return valueReader.read(new ByteArrayInputStream(d.getData()));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    @Override
+    public StorageKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ScaleReader<V> getValueReader() {
+        return valueReader;
+    }
+
+    @Override
+    public void consume(@NonNull KeyConsumer consumer) {
+        val keys = keyExtractor.apply(key);
+
+        consumer.accept(keys);
+    }
+
+    @Override
+    public MultiQuery<Object> join(QueryableKey<?>... others) {
+        return () -> rpc
+                .state()
+                .queryStorageAt(concatKeys(others))
+                .thenApplyAsync(changeSets -> DiverseKeyValueCollection.with(
+                        changeSets.stream()
+                                .flatMap(set -> set.getChanges().stream())
+                                .collect(Collectors.toList()),
+                        concatReaders(others),
+                        concatKeyExtractors(others)
+
+                ));
+    }
+
+    @Override
+    public List<Object> extractKeys(@NonNull StorageKey fullKey) {
+        return keyExtractor.apply(fullKey);
+    }
+
+    private ArrayList<StorageKey> concatKeys(QueryableKey<?>[] others) {
+        val list = new ArrayList<>(Collections.singletonList(getKey()));
+        list.addAll(Arrays.stream(others).map(QueryableKey::getKey).collect(Collectors.toList()));
+
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ScaleReader<Object>> concatReaders(QueryableKey<?>[] others) {
+        val list = new ArrayList<>(Collections.singletonList((ScaleReader<Object>) getValueReader()));
+        list.addAll(Arrays.stream(others).map(q -> (ScaleReader<Object>) q.getValueReader()).collect(Collectors.toList()));
+
+        return list;
+    }
+
+    private ArrayList<Function<StorageKey, List<Object>>> concatKeyExtractors(QueryableKey<?>[] others) {
+        val list = new ArrayList<Function<StorageKey, List<Object>>>(Collections.singletonList(this::extractKeys));
+        list.addAll(Arrays.stream(others).map(q -> (Function<StorageKey, List<Object>>) q::extractKeys).collect(Collectors.toList()));
+
+        return list;
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageChangeConsumer.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageChangeConsumer.java
@@ -1,0 +1,24 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+
+import java.util.List;
+
+/**
+ * Represents an operation that accepts
+ * exception, hash of the block where change happened,
+ * the value and list of the keys of the entry.
+ * Doesn't return result.
+ * @param <V> the type of the value.
+ */
+@FunctionalInterface
+public interface StorageChangeConsumer<V> {
+    /**
+     * Performs this operation on the given arguments.
+     * @param exception happened on event.
+     * @param block hash of the block where the change happened.
+     * @param value new value of the storage's entry.
+     * @param keys list of the storage entry's keys.
+     */
+    void accept(Exception exception, BlockHash block, V value, List<Object> keys);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageDoubleMap.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageDoubleMap.java
@@ -1,0 +1,14 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import lombok.NonNull;
+
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+public interface StorageDoubleMap<F, S, V> {
+    CompletableFuture<V> get(@NonNull F first, @NonNull S second);
+
+    CompletableFuture<V> at(@NonNull BlockHash block, @NonNull F first, @NonNull S second);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageDoubleMapImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageDoubleMapImpl.java
@@ -1,0 +1,38 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+@RequiredArgsConstructor(staticName = "with")
+public class StorageDoubleMapImpl<F, S, V> implements StorageDoubleMap<F, S, V> {
+    private final StorageNMap<V> underlying;
+
+    private StorageDoubleMapImpl(@NonNull Rpc rpc,
+                                 @NonNull ScaleReader<V> scaleReader,
+                                 @NonNull StorageKeyProvider storageKeyProvider) {
+        underlying = StorageNMapImpl.with(rpc, scaleReader, storageKeyProvider);
+    }
+
+    public static <F, S, V> StorageDoubleMap<F, S, V> with(@NonNull Rpc rpc,
+                                                           @NonNull ScaleReader<V> scaleReader,
+                                                           @NonNull StorageKeyProvider storageKeyProvider) {
+        return new StorageDoubleMapImpl<>(rpc, scaleReader, storageKeyProvider);
+    }
+
+    @Override
+    public CompletableFuture<V> get(@NonNull F first, @NonNull S second) {
+        return underlying.get(first, second);
+    }
+
+    @Override
+    public CompletableFuture<V> at(@NonNull BlockHash block, @NonNull F first, @NonNull S second) {
+        return underlying.at(block, first, second);
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageKeyProvider.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageKeyProvider.java
@@ -1,0 +1,154 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.base.Preconditions;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import lombok.*;
+import net.openhft.hashing.LongHashFunction;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Operates with StorageKey for a certain pallet and a storage.
+ */
+public class StorageKeyProvider {
+    private static final int XX_HASH_SIZE = 16;
+    @Getter(AccessLevel.PACKAGE)
+    private final List<KeyHasher<?>> keyHashers = new ArrayList<>();
+    private final ByteBuffer keyPrefix;
+
+    private StorageKeyProvider(String palletName, String storageName) {
+        keyPrefix = ByteBuffer.allocate(XX_HASH_SIZE * 2);
+
+        xxHash128(keyPrefix, palletName);
+        xxHash128(keyPrefix, storageName);
+    }
+
+    private static void xxHash128(ByteBuffer buf, String value) {
+        val encodedValue = value.getBytes(StandardCharsets.UTF_8);
+
+        final ByteOrder sourceOrder = buf.order(); // final ByteOrder instead of val because of checkstyle
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+
+        buf.asLongBuffer()
+                .put(LongHashFunction.xx(0).hashBytes(encodedValue))
+                .put(LongHashFunction.xx(1).hashBytes(encodedValue));
+
+        buf.position(buf.position() + XX_HASH_SIZE);
+        buf.order(sourceOrder);
+    }
+
+    public static StorageKeyProvider of(@NonNull String palletName, @NonNull String storageName) {
+        return new StorageKeyProvider(palletName, storageName);
+    }
+
+    public StorageKeyProvider use(@NonNull KeyHasher<?>... hashers) {
+        Preconditions.checkState(keyHashers.isEmpty(),
+                "Key hashers are already set.");
+
+        Collections.addAll(keyHashers, hashers);
+
+        return this;
+    }
+
+    /**
+     * @param keys values of the keys for request to the entry
+     *             Note: all the keys must follow the same exact order as
+     *             they appear in the storage.
+     * @return combined StorageKey that contains concatenated pallet name, storage name
+     * and hashes of keys encoded by certain algorithms.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public StorageKey get(@NonNull Object... keys) {
+        if (keys.length > keyHashers.size()) {
+            throw new IndexOutOfBoundsException(
+                    String.format("Number of keys mustn't exceed capacity. Passed: %s, capacity: %s.",
+                            keys.length,
+                            keyHashers.size()));
+        }
+
+        val stream = new ByteArrayOutputStream();
+        try {
+            stream.write(keyPrefix.array());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        for (var i = 0; i < keys.length; i++) {
+            try {
+                stream.write(((KeyHasher) keyHashers.get(i)).getHash(keys[i]));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return StorageKey.valueOf(stream.toByteArray());
+    }
+
+    /**
+     * @return number of all keys of the storage.
+     */
+    public int countOfKeys() {
+        return keyHashers.size();
+    }
+
+    /**
+     * @param fullKey StorageKey that contains pallet and storage names and all keys
+     *                of the storage's entry.
+     * @return all keys of the entry.
+     */
+    public List<Object> extractKeys(StorageKey fullKey) {
+        val stream = new ByteArrayInputStream(Arrays.copyOfRange(fullKey.getData(),
+                keyPrefix.capacity(),
+                fullKey.getData().length));
+
+        return keyHashers
+                .stream()
+                .map(keyHasher -> {
+                    try {
+                        return keyHasher.extractKey(stream);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @param fullKey StorageKey that contains pallet and storage names and all keys
+     *                of the entry.
+     * @param queryKey StorageKey that contains pallet and storage names
+     *                 and may contain some keys of the entry.
+     *                 Note: all the keys must follow the same exact order as
+     *                 their sequence in the storage.
+     * @param countOfKeysInQuery number of keys included in the queryKey.
+     * @return the remaining keys of the entry which are not included in the queryKey.
+     */
+    public List<Object> extractKeys(StorageKey fullKey, StorageKey queryKey, int countOfKeysInQuery) {
+        val stream = new ByteArrayInputStream(Arrays.copyOfRange(fullKey.getData(),
+                queryKey.getData().length,
+                fullKey.getData().length));
+
+        return keyHashers
+                .stream()
+                .skip(countOfKeysInQuery)
+                .map(keyHasher -> {
+                    try {
+                        return keyHasher.extractKey(stream);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageMap.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageMap.java
@@ -1,0 +1,19 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+public interface StorageMap<K, V> {
+    CompletableFuture<V> get(@NonNull K key);
+
+    CompletableFuture<V> at(@NonNull BlockHash block, @NonNull K key);
+
+    CompletableFuture<List<Pair<BlockHash, List<V>>>> history(@NonNull K key);
+}
+

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageMapImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageMapImpl.java
@@ -1,0 +1,43 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+public class StorageMapImpl<K, V> implements StorageMap<K, V> {
+    private final StorageNMap<V> underlying;
+
+    private StorageMapImpl(@NonNull Rpc rpc,
+                           @NonNull ScaleReader<V> scaleReader,
+                           @NonNull StorageKeyProvider storageKeyProvider) {
+        underlying = StorageNMapImpl.with(rpc, scaleReader, storageKeyProvider);
+    }
+
+    public static <K, V> StorageMap<K, V> with(@NonNull Rpc rpc,
+                                        @NonNull ScaleReader<V> scaleReader,
+                                        @NonNull StorageKeyProvider storageKeyProvider) {
+        return new StorageMapImpl<>(rpc, scaleReader, storageKeyProvider);
+    }
+
+    @Override
+    public CompletableFuture<V> get(@NonNull K key) {
+        return underlying.get(key);
+    }
+
+    @Override
+    public CompletableFuture<V> at(@NonNull BlockHash block, @NonNull K key) {
+        return underlying.at(block, key);
+    }
+
+    @Override
+    public CompletableFuture<List<Pair<BlockHash, List<V>>>> history(@NonNull K key) {
+        return underlying.history(key);
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageNMap.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageNMap.java
@@ -1,0 +1,159 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.rpc.types.Hash;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * Represents a storage of data in blockchain
+ * that persists between the blocks.
+ * @param <V> the type of the value.
+ */
+public interface StorageNMap<V> {
+    /**
+     * Returns the value by given key(s).
+     * @param keys the keys of the storage's entry.
+     * @return the value.
+     */
+    CompletableFuture<V> get(@NonNull Object... keys);
+
+    /**
+     * Returns the value by given key(s)
+     * starting at block hash given as the first parameter.
+     * @param block hash of the block
+     *              used as a starting point for the value request.
+     * @param keys the keys of the storage's entry.
+     * @return the value.
+     */
+    CompletableFuture<V> at(@NonNull BlockHash block, @NonNull Object... keys);
+
+    /**
+     * Retrieves the storage hash.
+     * @param keys the keys of the storage's entry.
+     * @return the hash.
+     */
+    CompletableFuture<Hash> hash(@NonNull Object... keys);
+
+    /**
+     * Retrieves the storage hash
+     * starting at block hash given as the first parameter.
+     * @param block hash of the block
+     *              used as a starting point for the hash request.
+     * @param keys the keys of the storage's entry.
+     * @return the hash.
+     */
+    CompletableFuture<Hash> hashAt(@NonNull BlockHash block, @NonNull Object... keys);
+
+    /**
+     * Retrieves the storage size.
+     * @param keys the keys of the storage's entry.
+     * @return the size of the entry.
+     */
+    CompletableFuture<Long> size(@NonNull Object... keys);
+
+    /**
+     * Retrieves the storage size
+     * starting at block hash given as the first parameter.
+     * @param block hash of the block
+     *              used as a starting point for the size request.
+     * @param keys the keys of the storage's entry.
+     * @return the size of the entry.
+     */
+    CompletableFuture<Long> sizeAt(@NonNull BlockHash block, @NonNull Object... keys);
+
+    /**
+     * Returns a collection of keys, each item of which
+     * contains the remaining keys of the entry.
+     * @param keys some keys of the storage's entry.
+     *             Note: all the keys must follow the same strict order as
+     *             they appear in the storage.
+     * @return collection of keys.
+     */
+    CompletableFuture<KeyCollection<V>> keys(@NonNull Object... keys);
+
+
+    /**
+     * Returns a collection of keys, each item of which
+     * contains the remaining keys of the entry.
+     * @param block hash of the block
+     *              since that the keys are requested.
+     * @param keys some keys of the storage's entry.
+     *             Note: all the keys must follow the same strict order as
+     *             their sequence in the storage.
+     * @return collection of keys.
+     */
+    CompletableFuture<KeyCollection<V>> keysAt(@NonNull BlockHash block, @NonNull Object... keys);
+
+    /**
+     * Returns an iterator of a key collection, each item of which
+     * contains the remaining keys of the entry.
+     * Each item of the iterator contains a key collection with size equal to the page's size
+     * or smaller in case of the last page and the total number isn't multiple of the page's size.
+     * @param pageSize number of items in collection per page.
+     * @param keys some keys of the storage's entry.
+     *             Note: all the keys must follow the same strict order as
+     *             their sequence in the storage.
+     * @return iterator of key collections.
+     */
+    PagedKeyIterator<V> keysPaged(int pageSize, @NonNull Object... keys);
+
+    /**
+     * @param keys the keys of the storage's entry.
+     * @return the queryable key that allows to request value.
+     * The queryable key can also be joined to other keys for forming a multi query.
+     */
+    QueryableKey<V> query(@NonNull Object... keys);
+
+    /**
+     * @param keys the keys of the storage's entry.
+     * @return list of pairs. Each pair contains a hash of the block
+     * where the change(s) happened and list of values.
+     */
+    CompletableFuture<List<Pair<BlockHash, List<V>>>> history(@NonNull Object... keys);
+
+    /**
+     * Returns a key-value collection, each item of which
+     * contains the remaining keys of the entry and its value.
+     * @param keys some keys of the storage's entry.
+     *             Note: all the keys must follow the same strict order as
+     *             they appear in the storage.
+     * @return collection of key-values.
+     */
+    CompletableFuture<KeyValueCollection<V>> entries(@NonNull Object... keys);
+
+    /**
+     * Returns an iterator of a key-value collection, each item of which
+     * contains the remaining keys and the value.
+     * Each item of the iterator contains a key-value collection with size equal to the page's size
+     * or smaller in case of the last page and the total number isn't multiple of tbe page's size.
+     * @param pageSize number of items in collection per page.
+     * @param keys some keys of the storage's entry.
+     *             Note: all the keys must follow the same strict order as
+     *             their sequence in the storage.
+     * @return collection of key-values.
+     */
+    PagedKeyValueIterator<V> entriesPaged(int pageSize, @NonNull Object... keys);
+
+    /**
+     * Returns a collection of key-values, each item of which
+     * contains all the keys of the entry and its value.
+     * @param args any number of arguments to request
+     *             multiple entries.
+     * @return collection of key-value.
+     */
+    CompletableFuture<KeyValueCollection<V>> multi(@NonNull Arg... args);
+
+    /**
+     * Subscribes for changes on storage's entries with given args.
+     * @param consumer that consumes changes.
+     * @param args any number of arguments.
+     * @return an operation that allows to unsubscribe.
+     */
+    CompletableFuture<Supplier<CompletableFuture<Boolean>>> subscribe(@NonNull StorageChangeConsumer<V> consumer,
+                                                                      @NonNull Arg... args);
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageNMapImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageNMapImpl.java
@@ -1,0 +1,364 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.rpc.types.Hash;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * @param <V> the type of the value.
+ */
+@RequiredArgsConstructor(staticName = "with")
+public class StorageNMapImpl<V> implements StorageNMap<V> {
+    private final @NonNull Rpc rpc;
+    private final @NonNull ScaleReader<V> scaleReader;
+    private final @NonNull StorageKeyProvider storageKeyProvider;
+
+    @Override
+    public CompletableFuture<V> get(@NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorage(storageKeyProvider.get(keys))
+                .thenApplyAsync(d -> {
+                    if (d == null) {
+                        return null;
+                    }
+
+                    try {
+                        return scaleReader.read(new ByteArrayInputStream(d.getData()));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    private void ensureAllKeysWerePassed(@NonNull Object[] keys) {
+        if (keys.length != storageKeyProvider.countOfKeys()) {
+            throw new IndexOutOfBoundsException(String.format("Incorrect number of keys were passed. Passed: %s, expected: %s.",
+                    keys.length,
+                    storageKeyProvider.countOfKeys()));
+        }
+    }
+
+    @Override
+    public CompletableFuture<V> at(@NonNull BlockHash block, @NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorage(storageKeyProvider.get(keys), block)
+                .thenApplyAsync(d -> {
+                    if (d == null) {
+                        return null;
+                    }
+
+                    try {
+                        return scaleReader.read(new ByteArrayInputStream(d.getData()));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    @Override
+    public CompletableFuture<Hash> hash(@NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorageHash(storageKeyProvider.get(keys));
+    }
+
+    @Override
+    public CompletableFuture<Hash> hashAt(@NonNull BlockHash block, @NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorageHash(storageKeyProvider.get(keys), block);
+    }
+
+    @Override
+    public CompletableFuture<Long> size(@NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorageSize(storageKeyProvider.get(keys));
+    }
+
+    @Override
+    public CompletableFuture<Long> sizeAt(@NonNull BlockHash block, @NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .getStorageSize(storageKeyProvider.get(keys), block);
+    }
+
+    @Override
+    public CompletableFuture<KeyCollection<V>> keys(@NonNull Object... keys) {
+        val queryKey = storageKeyProvider.get(keys);
+        return rpc
+                .state()
+                .getKeys(queryKey)
+                .thenApplyAsync(storageKeys -> KeyCollectionImpl.with(rpc,
+                        storageKeys,
+                        scaleReader,
+                        key -> storageKeyProvider.extractKeys(key, queryKey, keys.length)));
+    }
+
+    @Override
+    public CompletableFuture<KeyCollection<V>> keysAt(@NonNull BlockHash block, @NonNull Object... keys) {
+        val queryKey = storageKeyProvider.get(keys);
+        return rpc
+                .state()
+                .getKeys(queryKey, block)
+                .thenApplyAsync(storageKeys -> KeyCollectionImpl.with(rpc,
+                        storageKeys,
+                        scaleReader,
+                        key -> storageKeyProvider.extractKeys(key, queryKey, keys.length)));
+    }
+
+    @Override
+    public PagedKeyIterator<V> keysPaged(int pageSize, @NonNull Object... keys) {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Number of elements per page must be positive.");
+        }
+
+        val queryKey = storageKeyProvider.get(keys);
+
+        return new PagedKeyIterator<V>() {
+            private int pageNumber = 0;
+            private int size = 0;
+            private boolean doesCurrentExist = false;
+            private StorageKey last;
+            private KeyCollection<V> collection;
+
+            @Override
+            public int number() {
+                if (!doesCurrentExist) {
+                    throw new NoSuchElementException();
+                }
+
+                return pageNumber;
+            }
+
+            @Override
+            public CompletableFuture<Boolean> moveNext() {
+                val task = pageNumber == 0 ?
+                        rpc.state().getKeysPaged(queryKey, pageSize) :
+                        size == pageSize ?
+                                rpc.state().getKeysPaged(queryKey, pageSize, last) :
+                                CompletableFuture.completedFuture(Collections.<StorageKey>emptyList());
+
+                return task
+                        .thenApplyAsync(storageKeys -> {
+                            if ((size = storageKeys.size()) > 0) {
+                                doesCurrentExist = true;
+                                pageNumber++;
+                                last = storageKeys.get(storageKeys.size() - 1);
+                                collection = KeyCollectionImpl.with(rpc,
+                                        storageKeys,
+                                        scaleReader,
+                                        key -> storageKeyProvider.extractKeys(key, queryKey, keys.length));
+                            } else {
+                                doesCurrentExist = false;
+                            }
+
+                            return doesCurrentExist;
+                        });
+            }
+
+            @Override
+            public KeyCollection<V> current() {
+                if (!doesCurrentExist) {
+                    throw new NoSuchElementException();
+                }
+
+                return collection;
+            }
+        };
+    }
+
+    @Override
+    public QueryableKey<V> query(@NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return QueryableKeyImpl.with(rpc,
+                storageKeyProvider.get(keys),
+                scaleReader,
+                storageKeyProvider::extractKeys);
+    }
+
+    @Override
+    public CompletableFuture<List<Pair<BlockHash, List<V>>>> history(@NonNull Object... keys) {
+        ensureAllKeysWerePassed(keys);
+
+        return rpc
+                .state()
+                .queryStorageAt(Collections.singletonList(storageKeyProvider.get(keys)))
+                .thenApplyAsync(set -> set
+                        .stream()
+                        .map(s -> Pair.of(
+                                s.getBlock(),
+                                s
+                                        .getChanges()
+                                        .stream()
+                                        .map(p -> Optional.of(p.getValue1())
+                                                .map(v -> {
+                                                    try {
+                                                        return scaleReader.read(new ByteArrayInputStream(v.getData()));
+                                                    } catch (IOException e) {
+                                                        throw new RuntimeException(e);
+                                                    }
+                                                })
+                                                .orElse(null))
+                                        .collect(Collectors.toList())))
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<KeyValueCollection<V>> entries(@NonNull Object... keys) {
+        return keys(keys).thenComposeAsync(k -> k.multi().execute());
+    }
+
+    @Override
+    public PagedKeyValueIterator<V> entriesPaged(int pageSize, @NonNull Object... keys) {
+        return new PagedKeyValueIterator<V>() {
+            private final PagedKeyIterator<V> underlying = keysPaged(pageSize, keys);
+            private KeyValueCollection<V> collection;
+
+            @Override
+            public int number() {
+                if (collection == null) {
+                    throw new NoSuchElementException();
+                }
+
+                return underlying.number();
+            }
+
+            @Override
+            public CompletableFuture<Boolean> moveNext() {
+                val values = new CompletableFuture<KeyValueCollection<V>>();
+                underlying.moveNext()
+                        .whenCompleteAsync((next, throwable) -> {
+                            if (throwable != null) {
+                                values.completeExceptionally(throwable);
+                            } else {
+                                if (next) {
+                                    underlying.current().multi().execute()
+                                            .whenCompleteAsync((keyValues, e) -> {
+                                                if (e != null) {
+                                                    values.completeExceptionally(e);
+                                                } else {
+                                                    values.complete(keyValues);
+                                                }
+                                            });
+                                } else {
+                                    values.complete(null);
+                                }
+                            }
+                        });
+
+                return values
+                        .whenCompleteAsync((keyValues, throwable) -> {
+                            if (throwable == null) {
+                                collection = keyValues;
+                            }
+                        }).thenApplyAsync(Objects::nonNull);
+            }
+
+            @Override
+            public KeyValueCollection<V> current() {
+                if (collection == null) {
+                    throw new NoSuchElementException();
+                }
+
+                return collection;
+            }
+        };
+    }
+
+    @Override
+    public CompletableFuture<KeyValueCollection<V>> multi(@NonNull Arg... args) {
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Multi requests are not supported without arguments.");
+        }
+
+        val keys = Arrays.stream(args)
+                .map(a -> {
+                    ensureAllKeysWerePassed(a.getList());
+
+                    return storageKeyProvider.get(a.getList());
+                })
+                .collect(Collectors.toList());
+
+        return rpc
+                .state()
+                .queryStorageAt(keys)
+                .thenApplyAsync(set -> {
+                    val pairs = set
+                            .stream()
+                            .flatMap(changeSet -> changeSet.getChanges().stream())
+                            .collect(Collectors.toList());
+
+                    return HomogeneousKeyValueCollection.with(pairs,
+                            scaleReader,
+                            storageKeyProvider::extractKeys);
+                });
+    }
+
+    @Override
+    public CompletableFuture<Supplier<CompletableFuture<Boolean>>> subscribe(@NonNull StorageChangeConsumer<V> consumer, @NonNull Arg... args) {
+        if (args.length == 0) {
+            throw new IllegalArgumentException("Subscription can't be requested with no arguments.");
+        }
+
+        val queryKeys = Arrays.stream(args)
+                .map(a -> {
+                    ensureAllKeysWerePassed(a.getList());
+
+                    return storageKeyProvider.get(a.getList());
+                })
+                .collect(Collectors.toList());
+
+        return rpc
+                .state()
+                .subscribeStorage(queryKeys, (e, changeSet) -> {
+                    if (e != null) {
+                        consumer.accept(e, null, null, null);
+                    } else {
+                        changeSet.getChanges().forEach(
+                                p -> {
+                                    try {
+                                        val value = p.getValue1() == null ?
+                                                null :
+                                                scaleReader.read(new ByteArrayInputStream(p.getValue1().getData()));
+
+                                        val keys = storageKeyProvider.extractKeys(p.getValue0());
+                                        consumer.accept(null, changeSet.getBlock(), value, keys);
+                                    } catch (IOException ex) {
+                                        throw new RuntimeException(ex);
+                                    }
+                                }
+                        );
+                    }
+                });
+    }
+
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageValue.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageValue.java
@@ -1,0 +1,20 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+public interface StorageValue<V> {
+    CompletableFuture<V> get();
+
+    CompletableFuture<V> at(@NonNull BlockHash block);
+
+    CompletableFuture<List<Pair<BlockHash, List<V>>>> history();
+
+    QueryableKey<V> query();
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageValueImpl.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/StorageValueImpl.java
@@ -1,0 +1,50 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.google.common.annotations.Beta;
+import com.strategyobject.substrateclient.rpc.Rpc;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Beta
+@RequiredArgsConstructor(staticName = "with")
+public class StorageValueImpl<V> implements StorageValue<V> {
+    private final StorageNMap<V> underlying;
+
+    private StorageValueImpl(@NonNull Rpc rpc,
+                             @NonNull ScaleReader<V> scaleReader,
+                             @NonNull StorageKeyProvider storageKeyProvider) {
+        underlying = StorageNMapImpl.with(rpc, scaleReader, storageKeyProvider);
+    }
+
+    public static <V> StorageValue<V> with(@NonNull Rpc rpc,
+                                           @NonNull ScaleReader<V> scaleReader,
+                                           @NonNull StorageKeyProvider storageKeyProvider) {
+        return new StorageValueImpl<>(rpc, scaleReader, storageKeyProvider);
+    }
+
+    @Override
+    public CompletableFuture<V> get() {
+        return underlying.get();
+    }
+
+    @Override
+    public CompletableFuture<V> at(@NonNull BlockHash block) {
+        return underlying.at(block);
+    }
+
+    @Override
+    public CompletableFuture<List<Pair<BlockHash, List<V>>>> history() {
+        return underlying.history();
+    }
+
+    @Override
+    public QueryableKey<V> query() {
+        return underlying.query();
+    }
+}

--- a/storage/src/main/java/com/strategyobject/substrateclient/storage/TwoX64Concat.java
+++ b/storage/src/main/java/com/strategyobject/substrateclient/storage/TwoX64Concat.java
@@ -1,0 +1,73 @@
+package com.strategyobject.substrateclient.storage;
+
+import lombok.NonNull;
+import lombok.val;
+import net.openhft.hashing.LongHashFunction;
+
+import java.nio.ByteBuffer;
+
+/**
+ * TwoX 64 Concat hash algorithm.
+ * This algorithm is non-cryptographic and transparent.
+ * It's used to generate storage map's key.
+ */
+public class TwoX64Concat implements KeyHashingAlgorithm {
+    private static final int XX_HASH_SIZE = 8;
+    private static volatile TwoX64Concat instance;
+
+    private static byte[] xxHash64(byte[] value) {
+        val hash = LongHashFunction.xx(0).hashBytes(value);
+
+        return new byte[]{
+                (byte) (hash),
+                (byte) (hash >> 8),
+                (byte) (hash >> 16),
+                (byte) (hash >> 24),
+                (byte) (hash >> 32),
+                (byte) (hash >> 40),
+                (byte) (hash >> 48),
+                (byte) (hash >> 56)
+        };
+    }
+
+    private static byte[] xxHash64Concat(byte[] value) {
+        val buf = ByteBuffer.allocate(XX_HASH_SIZE + value.length);
+
+        buf.put(xxHash64(value));
+        buf.put(value);
+
+        return buf.array();
+    }
+
+    /**
+     * @return the instance of the algorithm.
+     */
+    public static TwoX64Concat getInstance() {
+        if (instance == null) {
+            synchronized (TwoX64Concat.class) {
+                if (instance == null) {
+                    instance = new TwoX64Concat();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * @param encodedKey binary data that represents the encoded key.
+     * @return hash for given key.
+     */
+    @Override
+    public byte[] getHash(byte @NonNull [] encodedKey) {
+        return xxHash64Concat(encodedKey);
+    }
+
+    /**
+     * @return size of the algorithm.
+     */
+    @Override
+    public int hashSize() {
+        return XX_HASH_SIZE;
+    }
+
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/Blake2B128ConcatTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/Blake2B128ConcatTests.java
@@ -1,0 +1,60 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Blake2B128ConcatTests {
+    private static Stream<Arguments> getTestCasesForGetHash() {
+        return Stream.of(
+                Arguments.of(
+                        decode(Integer.class, 5),
+                        "0x969e061847da7e84337ea78dc577cd1d05000000"
+                ),
+                Arguments.of(
+                        decode(String.class, "SomeString"),
+                        "0x054439e9cc46decbb601602ece91182c28536f6d65537472696e67"
+                ),
+                Arguments.of(
+                        decode(AccountId.class,
+                                AccountId.fromBytes(
+                                        SS58Codec.decode(
+                                                        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                                                .getAddress())),
+                        "0xde1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+                )
+        );
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private static <T> byte[] decode(Class<T> type, T value) {
+        val buf = new ByteArrayOutputStream();
+        ((ScaleWriter<T>) ScaleWriterRegistry.getInstance().resolve(type)).write(value, buf);
+
+        return buf.toByteArray();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetHash")
+    public void getHash(byte[] encodedKey, String expectedInHex) {
+        val algorithm = Blake2B128Concat.getInstance();
+
+        val actual = algorithm.getHash(encodedKey);
+        val actualInHex = HexConverter.toHex(actual);
+
+        assertEquals(expectedInHex, actualInHex);
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/IdentityTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/IdentityTests.java
@@ -1,0 +1,52 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IdentityTests {
+    private static Stream<byte[]> getTestCasesForGetHash() {
+        return Stream.of(
+                encode(Integer.class, -175),
+                encode(BlockHash.class, BlockHash.fromBytes(random(32))),
+                "TestString".getBytes(StandardCharsets.UTF_8),
+                random(new Random().nextInt(128) + 1));
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private static <T> byte[] encode(Class<T> type, T value) {
+        val buf = new ByteArrayOutputStream();
+        ((ScaleWriter<T>) ScaleWriterRegistry.getInstance().resolve(type)).write(value, buf);
+
+        return buf.toByteArray();
+    }
+
+    private static byte[] random(int length) {
+        val bytes = new byte[length];
+        new Random().nextBytes(bytes);
+
+        return bytes;
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetHash")
+    public void getHash(byte[] encodedKey) {
+        val algorithm = Identity.getInstance();
+
+        val actual = algorithm.getHash(encodedKey);
+
+        assertEquals(encodedKey, actual);
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/KeyHasherTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/KeyHasherTests.java
@@ -1,0 +1,166 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.readers.CompactIntegerReader;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import com.strategyobject.substrateclient.scale.writers.CompactIntegerWriter;
+import lombok.val;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KeyHasherTests {
+    private static Stream<Arguments> getTestCasesForGetHash() {
+        return Stream.of(
+                Arguments.of(
+                        10,
+                        ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                        ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                        TwoX64Concat.getInstance(),
+                        "0xa6b274250e6753f00a000000"
+                ),
+                Arguments.of(
+                        AccountId.fromBytes(
+                                SS58Codec.decode(
+                                                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                                        .getAddress()),
+                        ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                        ScaleWriterRegistry.getInstance().resolve(AccountId.class),
+                        Blake2B128Concat.getInstance(),
+                        "0x4f9aea1afa791265fae359272badc1cf8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"
+                ),
+                Arguments.of(
+                        BlockHash.fromBytes(HexConverter.toBytes("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
+                        ScaleReaderRegistry.getInstance().resolve(BlockHash.class),
+                        ScaleWriterRegistry.getInstance().resolve(BlockHash.class),
+                        Identity.getInstance(),
+                        "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                )
+        );
+    }
+
+    private static Stream<Arguments> getTestCasesForExtractKey() {
+        return Stream.of(
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0x5153cb1f00942ff401000000")
+                        ),
+                        ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                        ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                        TwoX64Concat.getInstance(),
+                        1,
+                        0
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0x969e061847da7e84337ea78dc577cd1d05000000")
+                        ),
+                        ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                        ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                        Blake2B128Concat.getInstance(),
+                        5,
+                        0
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0xa8")
+                        ),
+                        new CompactIntegerReader(),
+                        new CompactIntegerWriter(),
+                        Identity.getInstance(),
+                        42,
+                        0
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0x")
+                        ),
+                        ScaleReaderRegistry.getInstance().resolve(Void.class),
+                        ScaleWriterRegistry.getInstance().resolve(Void.class),
+                        Identity.getInstance(),
+                        null,
+                        0
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0x4f9aea1afa791265fae359272badc1cf8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48" +
+                                        "a6b274250e6753f00a000000")
+                        ),
+                        ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                        ScaleWriterRegistry.getInstance().resolve(AccountId.class),
+                        Blake2B128Concat.getInstance(),
+                        AccountId.fromBytes(
+                                SS58Codec.decode(
+                                                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                                        .getAddress()),
+                        HexConverter.toBytes("a6b274250e6753f00a000000").length
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0xabcdef98765432100123456789abcdefabcdef98765432100123456789abcdef")),
+                        ScaleReaderRegistry.getInstance().resolve(BlockHash.class),
+                        ScaleWriterRegistry.getInstance().resolve(BlockHash.class),
+                        Identity.getInstance(),
+                        BlockHash.fromBytes(HexConverter.toBytes("0xabcdef98765432100123456789abcdefabcdef98765432100123456789abcdef")),
+                        0
+                ),
+                Arguments.of(
+                        new ByteArrayInputStream(
+                                HexConverter.toBytes("0x518366b5b1bc7c99d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d")),
+                        ScaleReaderRegistry.getInstance().resolve(BlockHash.class),
+                        ScaleWriterRegistry.getInstance().resolve(BlockHash.class),
+                        TwoX64Concat.getInstance(),
+                        AccountId.fromBytes(
+                                SS58Codec.decode(
+                                                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                                        .getAddress()),
+                        0
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetHash")
+    public <T> void getHash(T key,
+                            ScaleReader<T> reader,
+                            ScaleWriter<T> writer,
+                            KeyHashingAlgorithm algorithm,
+                            String expectedInHex) throws IOException {
+        val hasher = KeyHasher.with(writer, reader, algorithm);
+        val actual = hasher.getHash(key);
+
+        val expected = HexConverter.toBytes(expectedInHex);
+        assertArrayEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForExtractKey")
+    public <T> void extractKey(InputStream stream,
+                               ScaleReader<T> reader,
+                               ScaleWriter<T> writer,
+                               KeyHashingAlgorithm algorithm,
+                               T expected,
+                               int expectedAvailable) throws IOException {
+        val hasher = KeyHasher.with(writer, reader, algorithm);
+        val actual = hasher.extractKey(stream);
+
+        assertEquals(expected, actual);
+
+        val available = stream.available();
+        assertEquals(expectedAvailable, available);
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageDoubleMapImplTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageDoubleMapImplTests.java
@@ -1,0 +1,61 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.RpcImpl;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
+import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.WsProvider;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Testcontainers
+public class StorageDoubleMapImplTests {
+    @Container
+    static final TestSubstrateContainer substrate = new TestSubstrateContainer(SubstrateVersion.V3_0_0);
+    private static final int CONNECTION_TIMEOUT = 1000;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void societyVotes() throws Exception {
+        val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build();
+        wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = StorageDoubleMapImpl.with(
+                    rpc,
+                    (ScaleReader<Void>) ScaleReaderRegistry.getInstance().resolve(Void.class),
+                    StorageKeyProvider.of("Society", "Votes")
+                            .use(KeyHasher.with((ScaleWriter<AccountId>) ScaleWriterRegistry.getInstance().resolve(AccountId.class),
+                                            (ScaleReader<AccountId>) ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                                            TwoX64Concat.getInstance()),
+                                    KeyHasher.with((ScaleWriter<AccountId>) ScaleWriterRegistry.getInstance().resolve(AccountId.class),
+                                            (ScaleReader<AccountId>) ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                                            TwoX64Concat.getInstance())));
+            val alice = AccountId.fromBytes(
+                    SS58Codec.decode(
+                                    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                            .getAddress());
+            val bob = AccountId.fromBytes(
+                    SS58Codec.decode(
+                                    "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                            .getAddress());
+
+            val actual = storage.get(alice, bob).get();
+
+            assertNull(actual);
+        }
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageKeyProviderTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageKeyProviderTests.java
@@ -1,0 +1,253 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.rpc.types.StorageKey;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import lombok.NonNull;
+import lombok.val;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StorageKeyProviderTests {
+    @SuppressWarnings("unchecked")
+    private static Stream<Arguments> getTestCasesForGetBySingleKey() {
+        return Stream.of(
+                Arguments.of("Balances",
+                        "FreeBalance",
+                        KeyHasher.with(
+                                resolveWriter(AccountId.class),
+                                resolveReader(AccountId.class),
+                                Blake2B128Concat.getInstance()
+                        ),
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+                        "0x" +
+                                "c2261276cc9d1f8598ea4b6a74b15c2f" +
+                                "6482b9ade7bc6657aaca787ba1add3b4" +
+                                "de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"),
+
+                Arguments.of("System",
+                        "BlockHash",
+                        KeyHasher.with(
+                                (ScaleWriter<Integer>) ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                                (ScaleReader<Integer>) ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                                TwoX64Concat.getInstance()
+                        ),
+                        2,
+                        "0x" +
+                                "26aa394eea5630e07c48ae0c9558cef7" +
+                                "a44704b568d21667356a5a050c118746" +
+                                "9eb2dcce60f37a2702000000")
+        );
+    }
+
+    @SuppressWarnings({"unchecked", "SameParameterValue"})
+    private static <T> ScaleReader<T> resolveReader(Class<T> clazz) {
+        return (ScaleReader<T>) ScaleReaderRegistry.getInstance().resolve(clazz);
+    }
+
+    @SuppressWarnings({"unchecked", "SameParameterValue"})
+    private static <T> ScaleWriter<T> resolveWriter(Class<T> clazz) {
+        return (ScaleWriter<T>) ScaleWriterRegistry.getInstance().resolve(clazz);
+    }
+
+    private static Stream<Arguments> getTestCasesForGetByDoubleKey() {
+        return Stream.of(
+                Arguments.of("Society",
+                        "Votes",
+                        KeyHasher.with(
+                                resolveWriter(AccountId.class),
+                                resolveReader(AccountId.class),
+                                TwoX64Concat.getInstance()
+                        ),
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+                        KeyHasher.with(
+                                resolveWriter(AccountId.class),
+                                resolveReader(AccountId.class),
+                                TwoX64Concat.getInstance()
+                        ),
+                        newAccountId("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"),
+                        "0x" +
+                                "426e15054d267946093858132eb537f1" +
+                                "b4adc6a1ce4f7cc2e696ed0fd06bd01c" +
+                                "518366b5b1bc7c99d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d" +
+                                "a647e755c30521d38eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48")
+        );
+    }
+
+    private static Stream<Arguments> getTestCasesForExtractKeys() {
+        val providers = Arrays.asList(
+                newFreeBalanceKeyProvider(),
+                newVotesKeyProvider()
+        );
+
+        val keys = Arrays.asList(
+                Collections.singletonList(newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")),
+                Arrays.asList(
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+                        newAccountId("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                )
+        );
+
+        return IntStream
+                .range(0, providers.size())
+                .mapToObj(i -> Arguments.of(
+                        providers.get(i),
+                        providers.get(i).get(keys.get(i).toArray()),
+                        keys.get(i)
+                ));
+    }
+
+    @NonNull
+    private static AccountId newAccountId(String encoded) {
+        return AccountId.fromBytes(
+                SS58Codec.decode(
+                                encoded)
+                        .getAddress());
+    }
+
+    private static Stream<Arguments> getTestCasesForExtractKeysUsingQueryKey() {
+        val providers = Arrays.asList(
+                newFreeBalanceKeyProvider(),
+                newVotesKeyProvider(),
+                newVotesKeyProvider()
+        );
+
+        val allKeys = Arrays.asList(
+                Collections.singletonList(newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")),
+                Arrays.asList(
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+                        newAccountId("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                ),
+                Arrays.asList(
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+                        newAccountId("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                )
+        );
+
+        val queryKeys = Arrays.asList(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.singletonList(
+                        newAccountId("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                )
+        );
+
+        return IntStream
+                .range(0, providers.size())
+                .mapToObj(i -> Arguments.of(
+                        providers.get(i),
+                        providers.get(i).get(allKeys.get(i).toArray()),
+                        providers.get(i).get(queryKeys.get(i).toArray()),
+                        queryKeys.get(i).size(),
+                        allKeys.get(i).stream().skip(queryKeys.get(i).size()).collect(Collectors.toList())
+                ));
+    }
+
+    private static StorageKeyProvider newVotesKeyProvider() {
+        return StorageKeyProvider.of("Society", "Votes")
+                .use(KeyHasher.with(
+                                resolveWriter(AccountId.class),
+                                resolveReader(AccountId.class),
+                                TwoX64Concat.getInstance()
+                        ),
+                        KeyHasher.with(
+                                resolveWriter(AccountId.class),
+                                resolveReader(AccountId.class),
+                                TwoX64Concat.getInstance()
+                        )
+                );
+    }
+
+    private static StorageKeyProvider newFreeBalanceKeyProvider() {
+        return StorageKeyProvider.of("Balances", "FreeBalance")
+                .use(KeyHasher.with(
+                        resolveWriter(AccountId.class),
+                        resolveReader(AccountId.class),
+                        Blake2B128Concat.getInstance()
+                ));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "SomePallet,SomeStorage,0x832718a9c64cbad10dc0772e2c2d3d9c2e186e85ed8948269c15e1c78ccd4305",
+            "Sudo,Key,0x5c0d1176a568c1f92944340dbfed9e9c530ebca703c85910e7164cb7d1c9e47b"})
+    public void getWithoutKey(String pallet, String storage, String expectedInHex) {
+        val provider = StorageKeyProvider.of(pallet, storage);
+
+        val storageKey = provider.get();
+        val actualInHex = HexConverter.toHex(storageKey.getData());
+
+        assertEquals(expectedInHex, actualInHex);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetBySingleKey")
+    public <T> void getBySingleKey(String pallet,
+                                   String storage,
+                                   KeyHasher<T> keyHasher,
+                                   T key,
+                                   String expectedInHex) {
+        val provider = StorageKeyProvider.of(pallet, storage)
+                .use(keyHasher);
+
+        val storageKey = provider.get(key);
+        val actualInHex = HexConverter.toHex(storageKey.getData());
+
+        assertEquals(expectedInHex, actualInHex);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetByDoubleKey")
+    public <F, S> void getByDoubleKey(String pallet,
+                                      String storage,
+                                      KeyHasher<F> firstHasher,
+                                      F firstKey,
+                                      KeyHasher<S> secondHasher,
+                                      S secondKey,
+                                      String expectedInHex) {
+        val provider = StorageKeyProvider.of(pallet, storage)
+                .use(firstHasher, secondHasher);
+
+        val storageKey = provider.get(firstKey, secondKey);
+        val actualInHex = HexConverter.toHex(storageKey.getData());
+
+        assertEquals(expectedInHex, actualInHex);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForExtractKeys")
+    public void extractKeys(StorageKeyProvider provider, StorageKey fullKey, List<Object> expected) {
+        val actual = provider.extractKeys(fullKey);
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForExtractKeysUsingQueryKey")
+    public void extractKeysUsingQueryKey(StorageKeyProvider provider,
+                                                StorageKey fullKey,
+                                                StorageKey queryKey,
+                                                int countOfKeysInQuery,
+                                                List<Object> expected) {
+        val actual = provider.extractKeys(fullKey, queryKey, countOfKeysInQuery);
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageMapImplTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageMapImplTests.java
@@ -1,0 +1,50 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.rpc.RpcImpl;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
+import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.WsProvider;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Testcontainers
+public class StorageMapImplTests {
+    @Container
+    static final TestSubstrateContainer substrate = new TestSubstrateContainer(SubstrateVersion.V3_0_0);
+    private static final int CONNECTION_TIMEOUT = 1000;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void systemBlockHash() throws Exception {
+        val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build();
+        wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = StorageMapImpl.with(
+                    rpc,
+                    (ScaleReader<BlockHash>) ScaleReaderRegistry.getInstance().resolve(BlockHash.class),
+                    StorageKeyProvider.of("System", "BlockHash")
+                            .use(KeyHasher.with((ScaleWriter<Integer>) ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                                    (ScaleReader<Integer>) ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                                    TwoX64Concat.getInstance())));
+
+            val actual = storage.get(0).get();
+
+            assertNotEquals(BigInteger.ZERO, new BigInteger(actual.getData()));
+        }
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageNMapImplTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageNMapImplTests.java
@@ -1,0 +1,276 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.RpcImpl;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.rpc.types.BlockHash;
+import com.strategyobject.substrateclient.scale.ScaleReader;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
+import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.WsProvider;
+import com.strategyobject.substrateclient.types.tuples.Pair;
+import lombok.NonNull;
+import lombok.val;
+import lombok.var;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static org.testcontainers.shaded.org.hamcrest.number.OrderingComparison.greaterThan;
+
+@Testcontainers
+public class StorageNMapImplTests {
+    private static final int CONNECTION_TIMEOUT = 1000;
+    private static final int WAIT_TIMEOUT = 10;
+    @Container
+    private final TestSubstrateContainer substrate = new TestSubstrateContainer(SubstrateVersion.V3_0_0);
+
+    @SuppressWarnings("unchecked")
+    private static StorageNMapImpl<BlockHash> newSystemBlockHashStorage(RpcImpl rpc) {
+        return StorageNMapImpl.with(
+                rpc,
+                (ScaleReader<BlockHash>) ScaleReaderRegistry.getInstance().resolve(BlockHash.class),
+                StorageKeyProvider.of("System", "BlockHash")
+                        .use(KeyHasher.with((ScaleWriter<Integer>) ScaleWriterRegistry.getInstance().resolve(Integer.class),
+                                (ScaleReader<Integer>) ScaleReaderRegistry.getInstance().resolve(Integer.class),
+                                TwoX64Concat.getInstance())));
+    }
+
+    @NonNull
+    private WsProvider getConnectedProvider() throws InterruptedException, ExecutionException, TimeoutException {
+        val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build();
+        wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        return wsProvider;
+    }
+
+    @Test
+    public void keys() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = newSystemBlockHashStorage(rpc);
+
+            val collection = storage.keys().get();
+
+            assertNotNull(collection);
+            assertEquals(1, collection.size());
+
+            val blockNumber = new AtomicReference<Integer>(null);
+            collection.iterator().forEachRemaining(q -> q.consume((o -> blockNumber.set((Integer) o.get(0)))));
+
+            assertEquals(0, blockNumber.get());
+
+            val blocks = collection.multi().execute().get();
+            val list = new ArrayList<>();
+            blocks.iterator().forEachRemaining(e -> e.consume((value, keys) -> list.add(value)));
+
+            assertEquals(1, list.size());
+
+            val block = (BlockHash) list.stream().findFirst().orElseThrow(RuntimeException::new);
+            assertNotEquals(BigInteger.ZERO, new BigInteger(block.getData()));
+        }
+    }
+
+    @Test
+    public void multiToDifferentStorages() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storageValue = StorageNMapImpl.with(
+                    rpc,
+                    ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                    StorageKeyProvider.of("Sudo", "Key"));
+            val storageMap = newSystemBlockHashStorage(rpc);
+
+            val getKey = storageValue.query();
+            val getHash = storageMap.query(0);
+
+            val multi = getKey.join(getHash);
+            val collection = multi.execute().get();
+
+            val expectedKey = AccountId.fromBytes(
+                    SS58Codec.decode(
+                                    "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                            .getAddress());
+            val expectedBlock = storageMap.get(0).get();
+
+            val list = new ArrayList<>(2);
+            collection.iterator().forEachRemaining(e -> e.consume((value, keys) -> list.add(value)));
+
+            assertEquals(expectedKey, list.get(0));
+            assertEquals(expectedBlock, list.get(1));
+        }
+    }
+
+    @Test
+    public void entries() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = newSystemBlockHashStorage(rpc);
+
+            val collection = storage.entries().get();
+
+            assertNotNull(collection);
+
+            val blockNumber = new AtomicReference<Integer>(null);
+            val blockHash = new AtomicReference<BlockHash>(null);
+            collection.iterator().forEachRemaining(e -> e.consume((value, keys) -> {
+                blockHash.set(value);
+                blockNumber.set((Integer) keys.get(0));
+            }));
+
+            assertEquals(0, blockNumber.get());
+            assertNotEquals(BigInteger.ZERO, new BigInteger(blockHash.get().getData()));
+        }
+    }
+
+    @Test
+    public void multi() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = newSystemBlockHashStorage(rpc);
+
+            val collection = storage.multi(Arg.of(0), Arg.of(1)).get();
+            assertNotNull(collection);
+
+            val list = new ArrayList<Pair<Integer, BlockHash>>();
+            collection.iterator().forEachRemaining(e -> e.consume((value, keys) -> list.add(Pair.of((Integer) keys.get(0), value))));
+
+            assertEquals(2, list.size());
+
+            assertEquals(0, list.get(0).getValue0());
+            assertNotEquals(BigInteger.ZERO, new BigInteger(list.get(0).getValue1().getData()));
+
+            assertEquals(1, list.get(1).getValue0());
+            assertNull(list.get(1).getValue1());
+        }
+    }
+
+    @Test
+    public void keysPaged() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            waitForNewBlocks(rpc);
+
+            val storage = newSystemBlockHashStorage(rpc);
+
+            int pageSize = 2;
+            val pages = storage.keysPaged(pageSize);
+
+            assertNotNull(pages);
+
+            var pageCount = 0;
+            AtomicInteger total = new AtomicInteger();
+            while (pages.moveNext().join()) {
+                pages.current().iterator().forEachRemaining(queryableKey -> total.getAndIncrement());
+                pageCount++;
+                assertEquals(pageCount, pages.number());
+            }
+
+            assertTrue(pageCount > 1);
+            assertEquals(pageCount, Math.ceil((double) total.get() / pageSize));
+        }
+    }
+
+    @Test
+    public void entriesPaged() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            waitForNewBlocks(rpc);
+
+            val storage = newSystemBlockHashStorage(rpc);
+
+            int pageSize = 2;
+            val pages = storage.entriesPaged(pageSize);
+
+            assertNotNull(pages);
+
+            var pageCount = 0;
+            val pairs = new ArrayList<Pair<Integer, BlockHash>>();
+            while (pages.moveNext().join()) {
+                pages.current().iterator().forEachRemaining(e -> e.consume((value, keys) -> {
+                    val key = (Integer) keys.get(0);
+                    assertNotEquals(BigInteger.ZERO, new BigInteger(value.getData()));
+
+                    pairs.add(Pair.of(key, value));
+                }));
+                pageCount++;
+                assertEquals(pageCount, pages.number());
+            }
+
+            assertEquals(pairs.size(), pairs.stream().map(Pair::getValue0).collect(Collectors.toSet()).size());
+
+            assertTrue(pageCount > 1);
+            assertEquals(pageCount, Math.ceil((double) pairs.size() / pageSize));
+        }
+    }
+
+    @Test
+    public void subscribe() throws Exception {
+        val wsProvider = getConnectedProvider();
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val blockNumber = 2;
+            val storage = newSystemBlockHashStorage(rpc);
+            val blockHash = new AtomicReference<BlockHash>();
+            val value = new AtomicReference<BlockHash>();
+            val argument = new AtomicInteger();
+            val unsubscribe = storage.subscribe((exception, block, v, keys) -> {
+                        if (exception == null) {
+                            blockHash.set(block);
+                            value.set(v);
+                            argument.set((Integer) keys.get(0));
+                        }
+                    }, Arg.of(blockNumber))
+                    .get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            waitForNewBlocks(rpc);
+
+            val expectedValue = rpc.chain().getBlockHash(blockNumber).join();
+            val history = storage.history(blockNumber).join();
+            val changedAt = history.stream()
+                    .findFirst()
+                    .orElseThrow(RuntimeException::new)
+                    .getValue0();
+            val isUnsubscribed = unsubscribe.get().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+            assertTrue(isUnsubscribed);
+            assertEquals(changedAt, blockHash.get());
+            assertEquals(expectedValue, value.get());
+            assertEquals(expectedValue, value.get());
+            assertEquals(blockNumber, argument.get());
+        }
+    }
+
+    private void waitForNewBlocks(RpcImpl rpc) throws InterruptedException, ExecutionException, TimeoutException {
+        val blockCount = new AtomicInteger(0);
+        val unsubscribeFunc = rpc
+                .chain()
+                .subscribeNewHeads((e, h) -> {
+                    if (e == null) {
+                        blockCount.incrementAndGet();
+                    }
+                })
+                .get(WAIT_TIMEOUT, TimeUnit.SECONDS);
+
+        await()
+                .atMost(WAIT_TIMEOUT * 3, TimeUnit.SECONDS)
+                .untilAtomic(blockCount, greaterThan(3));
+
+        unsubscribeFunc.get().join();
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageValueImplTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/StorageValueImplTests.java
@@ -1,0 +1,73 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.RpcImpl;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.scale.registries.ScaleReaderRegistry;
+import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
+import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.WsProvider;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+public class StorageValueImplTests {
+    @Container
+    static final TestSubstrateContainer substrate = new TestSubstrateContainer(SubstrateVersion.V3_0_0);
+    private static final int CONNECTION_TIMEOUT = 1000;
+
+    @Test
+    public void sudoKey() throws Exception {
+        val expected = AccountId.fromBytes(
+                SS58Codec.decode(
+                                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                        .getAddress());
+
+        val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build();
+        wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val storage = StorageValueImpl.with(
+                    rpc,
+                    ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                    StorageKeyProvider.of("Sudo", "Key"));
+
+            val actual = storage.get().get();
+
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void sudoKeyAtGenesis() throws Exception {
+        val expected = AccountId.fromBytes(
+                SS58Codec.decode(
+                                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                        .getAddress());
+
+        val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .disableAutoConnect()
+                .build();
+        wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+        try (val rpc = new RpcImpl(wsProvider)) {
+            val blockHash = rpc.chain().getBlockHash(0).get();
+            val storage = StorageValueImpl.with(
+                    rpc,
+                    ScaleReaderRegistry.getInstance().resolve(AccountId.class),
+                    StorageKeyProvider.of("Sudo", "Key"));
+
+            val actual = storage.at(blockHash).get();
+
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/storage/src/test/java/com/strategyobject/substrateclient/storage/TwoX64ConcatTests.java
+++ b/storage/src/test/java/com/strategyobject/substrateclient/storage/TwoX64ConcatTests.java
@@ -1,0 +1,73 @@
+package com.strategyobject.substrateclient.storage;
+
+import com.strategyobject.substrateclient.common.utils.HexConverter;
+import com.strategyobject.substrateclient.crypto.ss58.SS58Codec;
+import com.strategyobject.substrateclient.rpc.types.AccountId;
+import com.strategyobject.substrateclient.scale.ScaleWriter;
+import com.strategyobject.substrateclient.scale.registries.ScaleWriterRegistry;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TwoX64ConcatTests {
+    private static Stream<Arguments> getTestCasesForGetHash() {
+        return Stream.of(
+                Arguments.of(
+                        decode(Integer.class, 10),
+                        "0xa6b274250e6753f00a000000"
+                ),
+                Arguments.of(
+                        "TestString".getBytes(StandardCharsets.UTF_8),
+                        "0x3cd20663ed09cfc954657374537472696e67"
+                ),
+                Arguments.of(
+                        "qwerty".getBytes(StandardCharsets.UTF_8),
+                        "0x7e918fd4671efe8a717765727479"
+                ),
+                Arguments.of(
+                        "abcd".getBytes(StandardCharsets.UTF_8),
+                        "0xcc925dd2b02703de61626364"
+                ),
+                Arguments.of(
+                        "Hello, World!".getBytes(StandardCharsets.UTF_8),
+                        "0x7fe40f08f8ac9ac448656c6c6f2c20576f726c6421"
+                ),
+                Arguments.of(
+                        decode(AccountId.class,
+                                AccountId.fromBytes(
+                                        SS58Codec.decode(
+                                                        "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                                                .getAddress())),
+                        "0x518366b5b1bc7c99d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+                )
+        );
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    private static <T> byte[] decode(Class<T> type, T value) {
+        val buf = new ByteArrayOutputStream();
+        ((ScaleWriter<T>) ScaleWriterRegistry.getInstance().resolve(type)).write(value, buf);
+
+        return buf.toByteArray();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTestCasesForGetHash")
+    public void getHash(byte[] encodedKey, String expectedInHex) {
+        val algorithm = new TwoX64Concat();
+
+        val actual = algorithm.getHash(encodedKey);
+        val actualInHex = HexConverter.toHex(actual);
+
+        assertEquals(expectedInHex, actualInHex);
+    }
+}


### PR DESCRIPTION
There is added interface `StorageNMap` that represents a storage of data in blockchain.
Added corresponding abstractions and entites such `KeyHashingAlgorithm`, `Blake2B128Concat`, `Identity`, `TwoX64Concat` and etc.
Added appropriate methods to section `State`.