### PR TITLE
There is fixed the issue of reconnection. `autoConnectMs` was changed…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'com.strategyobject.substrateclient'
-    version = '0.1.2-SNAPSHOT'
+    version = '0.1.3-SNAPSHOT'
 
     repositories {
         mavenLocal()

--- a/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageDoubleMapImplTests.java
+++ b/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageDoubleMapImplTests.java
@@ -8,6 +8,7 @@ import com.strategyobject.substrateclient.scale.ScaleReader;
 import com.strategyobject.substrateclient.scale.ScaleWriter;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class StorageDoubleMapImplTests {
     void societyVotes() throws Exception {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
             wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
 

--- a/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageMapImplTests.java
+++ b/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageMapImplTests.java
@@ -7,6 +7,7 @@ import com.strategyobject.substrateclient.scale.ScaleReader;
 import com.strategyobject.substrateclient.scale.ScaleWriter;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class StorageMapImplTests {
     void systemBlockHash() throws Exception {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
             wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
 

--- a/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageNMapImplTests.java
+++ b/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageNMapImplTests.java
@@ -13,6 +13,7 @@ import com.strategyobject.substrateclient.scale.ScaleWriter;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
 import com.strategyobject.substrateclient.transport.ProviderInterface;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.NonNull;
 import lombok.val;
@@ -56,7 +57,7 @@ class StorageNMapImplTests {
     private WsProvider getConnectedProvider() throws InterruptedException, ExecutionException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build();
         wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
         return wsProvider;

--- a/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageValueImplTests.java
+++ b/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageValueImplTests.java
@@ -8,6 +8,7 @@ import com.strategyobject.substrateclient.rpc.api.section.Chain;
 import com.strategyobject.substrateclient.rpc.api.section.State;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class StorageValueImplTests {
 
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
             wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
 
@@ -58,7 +59,7 @@ class StorageValueImplTests {
 
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
             wsProvider.connect().get(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
             val state = TestsHelper.createSectionFactory(wsProvider).create(State.class);

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
@@ -11,6 +11,7 @@ import com.strategyobject.substrateclient.scale.ScaleUtils;
 import com.strategyobject.substrateclient.scale.ScaleWriter;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import lombok.var;
@@ -121,7 +122,7 @@ class AuthorTests {
     private WsProvider connect() throws ExecutionException, InterruptedException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build();
 
         wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/ChainTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/ChainTests.java
@@ -4,6 +4,7 @@ import com.strategyobject.substrateclient.rpc.api.BlockHash;
 import com.strategyobject.substrateclient.rpc.api.BlockNumber;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
@@ -134,7 +135,7 @@ class ChainTests {
     private WsProvider connect() throws ExecutionException, InterruptedException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build();
 
         wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/StateTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/StateTests.java
@@ -5,6 +5,7 @@ import com.strategyobject.substrateclient.rpc.api.BlockNumber;
 import com.strategyobject.substrateclient.rpc.api.StorageKey;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Assertions;
@@ -176,7 +177,7 @@ class StateTests {
     private WsProvider connect() throws Exception {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build();
 
         wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/SystemTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/SystemTests.java
@@ -5,6 +5,7 @@ import com.strategyobject.substrateclient.rpc.api.AccountId;
 import com.strategyobject.substrateclient.rpc.api.Index;
 import com.strategyobject.substrateclient.tests.containers.SubstrateVersion;
 import com.strategyobject.substrateclient.tests.containers.TestSubstrateContainer;
+import com.strategyobject.substrateclient.transport.ws.ReconnectionPolicy;
 import com.strategyobject.substrateclient.transport.ws.WsProvider;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class SystemTests {
     void accountNextIndex() throws Exception {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
 

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/Delay.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/Delay.java
@@ -1,0 +1,28 @@
+package com.strategyobject.substrateclient.transport.ws;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents a delay
+ */
+@RequiredArgsConstructor(staticName = "of")
+@Getter
+public class Delay {
+    /**
+     * The time to delay execution unit
+     */
+    private final long value;
+
+    /**
+     * The time unit of the delay parameter
+     */
+    private final TimeUnit unit;
+
+    /**
+     * A delay that should never be scheduled
+     */
+    public static final Delay NEVER = Delay.of(-1, TimeUnit.SECONDS);
+}

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicy.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicy.java
@@ -1,0 +1,123 @@
+package com.strategyobject.substrateclient.transport.ws;
+
+import com.google.common.base.Preconditions;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Represents an exponential backoff retry policy
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Slf4j
+public class ExponentialBackoffReconnectionPolicy implements ReconnectionPolicy<LongAdder> {
+    /**
+     * Max number of attempts
+     */
+    private final long maxAttempts;
+    /**
+     * Initial delay, the time to delay execution unit
+     */
+    private final long delay;
+    /**
+     * The time unit of the delay parameter
+     */
+    private final TimeUnit unit;
+    /**
+     * Max delay
+     */
+    private final long maxDelay;
+    /**
+     * A multiplier that's applied to delay after every attempt
+     */
+    private final double factor;
+
+    /**
+     * @param context contains a reason of disconnection and counter of attempts
+     * @return a unit of time to delay the next reconnection
+     */
+    @Override
+    public @NonNull Delay getNextDelay(@NonNull ReconnectionContext<LongAdder> context) {
+        try {
+            if (context.getPolicyContext().longValue() >= maxAttempts) {
+                log.info("Provider won't reconnect more.");
+
+                return Delay.NEVER;
+            }
+
+            var nextDelay = delay * Math.pow(factor, context.getPolicyContext().longValue());
+            nextDelay = Math.min(nextDelay, maxDelay);
+
+            log.info("Provider will try to reconnect after: {} {}", nextDelay, unit);
+            return Delay.of((long) nextDelay, unit);
+        } finally {
+            context.getPolicyContext().increment();
+        }
+    }
+
+    /**
+     * Returns the counter of attempts
+     */
+    @Override
+    public LongAdder initContext() {
+        return new LongAdder();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long delay = 15;
+        private TimeUnit unit = TimeUnit.SECONDS;
+        private long maxDelay = 150;
+        private long maxAttempts = 10;
+        private double factor = 2;
+
+        Builder() {
+        }
+
+        public Builder retryAfter(long delay, TimeUnit unit) {
+            Preconditions.checkArgument(delay >= 0);
+
+            this.delay = delay;
+            this.unit = unit;
+
+            return this;
+        }
+
+        public Builder withFactor(double factor) {
+            Preconditions.checkArgument(factor > 0);
+
+            this.factor = factor;
+            return this;
+        }
+
+        public Builder withMaxDelay(long maxDelay) {
+            Preconditions.checkArgument(maxDelay >= 0);
+
+            this.maxDelay = maxDelay;
+            return this;
+        }
+
+        public Builder notMoreThan(long maxAttempts) {
+            Preconditions.checkArgument(maxAttempts >= 0);
+
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public ExponentialBackoffReconnectionPolicy build() {
+            return new ExponentialBackoffReconnectionPolicy(
+                    this.maxAttempts,
+                    this.delay,
+                    this.unit,
+                    this.maxDelay,
+                    this.factor
+            );
+        }
+    }
+}

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionContext.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionContext.java
@@ -1,0 +1,29 @@
+package com.strategyobject.substrateclient.transport.ws;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Represents a context why connection was closed
+ *
+ * @param <T> a type of policy's context required for
+ *            computing the next delay or other policy's purposes
+ */
+@RequiredArgsConstructor(staticName = "of")
+@Getter
+public class ReconnectionContext<T> {
+    /**
+     * The code of the reason of disconnection
+     */
+    private final int code;
+
+    /**
+     * The text of the reason
+     */
+    private final String reason;
+
+    /**
+     * The policy's context
+     */
+    private final T policyContext;
+}

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
@@ -1,0 +1,55 @@
+package com.strategyobject.substrateclient.transport.ws;
+
+import lombok.NonNull;
+
+/**
+ * @param <T> a type of policy's context required for
+ *            computing the next delay or other policy's purposes
+ *            Represents a strategy of reconnection
+ */
+public interface ReconnectionPolicy<T> {
+
+    /**
+     * The method is called when connection was closed and probably should be reconnected.
+     * @param context contains a reason of disconnection and policy's context.
+     * @return a unit of time from now to delay reconnection.
+     */
+    @NonNull Delay getNextDelay(@NonNull ReconnectionContext<T> context);
+
+    /**
+     * The method is called before the first connection or when the one successfully reestablished.
+     * @return a context required for the policy.
+     */
+    T initContext();
+
+    /**
+     * @return the builder of ExponentialBackoffReconnectionPolicy
+     */
+    static ExponentialBackoffReconnectionPolicy.Builder exponentialBackoff() {
+        return ExponentialBackoffReconnectionPolicy.builder();
+    }
+
+    /**
+     * @param <T> the type of context
+     * @return the policy that's supposed to not reconnect automatically
+     */
+    @SuppressWarnings("unchecked")
+    static <T> ReconnectionPolicy<T> manual() {
+        return (ReconnectionPolicy<T>) MANUAL;
+    }
+
+    /**
+     * The policy that's supposed to not reconnect automatically
+     */
+    ReconnectionPolicy<?> MANUAL = new ReconnectionPolicy<Void>() {
+        @Override
+        public @NonNull Delay getNextDelay(@NonNull ReconnectionContext<Void> context) {
+            return Delay.NEVER;
+        }
+
+        @Override
+        public Void initContext() {
+            return null;
+        }
+    };
+}

--- a/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicyTest.java
+++ b/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicyTest.java
@@ -1,0 +1,45 @@
+package com.strategyobject.substrateclient.transport.ws;
+
+import lombok.val;
+import lombok.var;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExponentialBackoffReconnectionPolicyTest {
+    @ParameterizedTest
+    @CsvSource({
+            "-1,10,20,SECONDS,5,1.5,7",
+            "10,5,10,SECONDS,10,2,10",
+            "20,5,100,SECONDS,10,2,3",
+            "10,10,10,MINUTES,10,2,10",
+            "5,100,5,MILLISECONDS,10,2,10",
+            "25,100,100,MILLISECONDS,3,0.5,3"})
+    void getNextDelay(long expected,
+                      long initialDelay,
+                      long maxDelay,
+                      TimeUnit unit,
+                      int maxAttempts,
+                      double factor,
+                      int iterations) {
+        val policy = ExponentialBackoffReconnectionPolicy.builder()
+                .retryAfter(initialDelay, unit)
+                .withFactor(factor)
+                .withMaxDelay(maxDelay)
+                .notMoreThan(maxAttempts)
+                .build();
+        val context = policy.initContext();
+
+        for (var i = 0; i < iterations - 1; i++) {
+            policy.getNextDelay(ReconnectionContext.of(-1, "some", context));
+        }
+
+        val delay = policy.getNextDelay(ReconnectionContext.of(-1, "some", context));
+
+        assertEquals(iterations, context.intValue());
+        assertEquals(expected, delay.getValue());
+    }
+}

--- a/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderTest.java
+++ b/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderTest.java
@@ -30,7 +30,7 @@ class WsProviderTest {
     void canConnect() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             assertDoesNotThrow(() -> wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS));
@@ -55,7 +55,7 @@ class WsProviderTest {
     void notifiesWhenConnected() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             val notified = new AtomicBoolean();
@@ -74,7 +74,7 @@ class WsProviderTest {
     void canCancelNotification() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             val notified = new AtomicBoolean();
@@ -91,7 +91,7 @@ class WsProviderTest {
     void canDisconnect() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -122,7 +122,7 @@ class WsProviderTest {
     void notifiesWhenDisconnected() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -143,7 +143,7 @@ class WsProviderTest {
     void canSend() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -159,7 +159,7 @@ class WsProviderTest {
     void canSubscribe() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -183,7 +183,7 @@ class WsProviderTest {
     void canUnsubscribe() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -210,7 +210,7 @@ class WsProviderTest {
     void sendThrowsRpcExceptions() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -225,7 +225,7 @@ class WsProviderTest {
     void supportsSubscriptions() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             assertTrue(wsProvider.hasSubscriptions());
@@ -237,7 +237,7 @@ class WsProviderTest {
     void canReconnectManually() {
         try (val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
-                .disableAutoConnect()
+                .withPolicy(ReconnectionPolicy.MANUAL)
                 .build()) {
 
             wsProvider.connect().get(WAIT_TIMEOUT, TimeUnit.SECONDS);


### PR DESCRIPTION
… by `ReconnectionPolicy`.

WsProvider couldn't reconnect to the web socket if it was closed - future `whenConnected` wasn't being completed when socket closes that blocked reconnection.