### PR TITLE
fix WsProvider typing

### DIFF
--- a/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageNMapImplTests.java
+++ b/pallet/src/test/java/com/strategyobject/substrateclient/pallet/storage/StorageNMapImplTests.java
@@ -54,7 +54,7 @@ class StorageNMapImplTests {
     }
 
     @NonNull
-    private WsProvider getConnectedProvider() throws InterruptedException, ExecutionException, TimeoutException {
+    private WsProvider<Void> getConnectedProvider() throws InterruptedException, ExecutionException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
                 .withPolicy(ReconnectionPolicy.MANUAL)

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/AuthorTests.java
@@ -122,7 +122,7 @@ class AuthorTests {
     }
 
 
-    private WsProvider connect() throws ExecutionException, InterruptedException, TimeoutException {
+    private WsProvider<Void> connect() throws ExecutionException, InterruptedException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
                 .withPolicy(ReconnectionPolicy.MANUAL)

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/ChainTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/ChainTests.java
@@ -132,7 +132,7 @@ class ChainTests {
         }
     }
 
-    private WsProvider connect() throws ExecutionException, InterruptedException, TimeoutException {
+    private WsProvider<Void> connect() throws ExecutionException, InterruptedException, TimeoutException {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
                 .withPolicy(ReconnectionPolicy.MANUAL)

--- a/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/StateTests.java
+++ b/rpc/rpc-api/src/test/java/com/strategyobject/substrateclient/rpc/api/section/StateTests.java
@@ -174,7 +174,7 @@ class StateTests {
         }
     }
 
-    private WsProvider connect() throws Exception {
+    private WsProvider<Void> connect() throws Exception {
         val wsProvider = WsProvider.builder()
                 .setEndpoint(substrate.getWsAddress())
                 .withPolicy(ReconnectionPolicy.MANUAL)

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
@@ -11,6 +11,7 @@ public interface ReconnectionPolicy<T> {
 
     /**
      * The method is called when connection was closed and probably should be reconnected.
+     *
      * @param context contains a reason of disconnection and policy's context.
      * @return a unit of time from now to delay reconnection.
      */
@@ -18,6 +19,7 @@ public interface ReconnectionPolicy<T> {
 
     /**
      * The method is called before the first connection or when the one successfully reestablished.
+     *
      * @return a context required for the policy.
      */
     T initContext();
@@ -41,7 +43,7 @@ public interface ReconnectionPolicy<T> {
     /**
      * The policy that's supposed to not reconnect automatically
      */
-    ReconnectionPolicy<?> MANUAL = new ReconnectionPolicy<Void>() {
+    ReconnectionPolicy<Void> MANUAL = new ReconnectionPolicy<Void>() {
         @Override
         public @NonNull Delay getNextDelay(@NonNull ReconnectionContext<Void> context) {
             return Delay.NEVER;


### PR DESCRIPTION
I removed the usage of raw types, but probably no generic typing is needed here. A policy can emit state as `Object` and consume `Object` back. The other guys are not interested in the type of this state.