### PR TITLE
made ReconnectionPolicy nongeneric

### DIFF
--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionContext.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionContext.java
@@ -5,13 +5,10 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * Represents a context why connection was closed
- *
- * @param <T> a type of policy's context required for
- *            computing the next delay or other policy's purposes
  */
 @RequiredArgsConstructor(staticName = "of")
 @Getter
-public class ReconnectionContext<T> {
+public class ReconnectionContext {
     /**
      * The code of the reason of disconnection
      */
@@ -23,7 +20,7 @@ public class ReconnectionContext<T> {
     private final String reason;
 
     /**
-     * The policy's context
+     * The policy's state
      */
-    private final T policyContext;
+    private final Object policyState;
 }

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/ws/ReconnectionPolicy.java
@@ -3,24 +3,24 @@ package com.strategyobject.substrateclient.transport.ws;
 import lombok.NonNull;
 
 /**
- * @param <T> a type of policy's context required for
- *            computing the next delay or other policy's purposes
- *            Represents a strategy of reconnection
+ * Policy required for computing the next delay. Represents a strategy of reconnection.
  */
-public interface ReconnectionPolicy<T> {
+public interface ReconnectionPolicy {
 
     /**
      * The method is called when connection was closed and probably should be reconnected.
+     *
      * @param context contains a reason of disconnection and policy's context.
      * @return a unit of time from now to delay reconnection.
      */
-    @NonNull Delay getNextDelay(@NonNull ReconnectionContext<T> context);
+    @NonNull Delay getNextDelay(@NonNull ReconnectionContext context);
 
     /**
      * The method is called before the first connection or when the one successfully reestablished.
+     *
      * @return a context required for the policy.
      */
-    T initContext();
+    Object initState();
 
     /**
      * @return the builder of ExponentialBackoffReconnectionPolicy
@@ -30,25 +30,16 @@ public interface ReconnectionPolicy<T> {
     }
 
     /**
-     * @param <T> the type of context
-     * @return the policy that's supposed to not reconnect automatically
-     */
-    @SuppressWarnings("unchecked")
-    static <T> ReconnectionPolicy<T> manual() {
-        return (ReconnectionPolicy<T>) MANUAL;
-    }
-
-    /**
      * The policy that's supposed to not reconnect automatically
      */
-    ReconnectionPolicy<?> MANUAL = new ReconnectionPolicy<Void>() {
+    ReconnectionPolicy MANUAL = new ReconnectionPolicy() {
         @Override
-        public @NonNull Delay getNextDelay(@NonNull ReconnectionContext<Void> context) {
+        public @NonNull Delay getNextDelay(@NonNull ReconnectionContext context) {
             return Delay.NEVER;
         }
 
         @Override
-        public Void initContext() {
+        public Void initState() {
             return null;
         }
     };

--- a/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicyTest.java
+++ b/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/ExponentialBackoffReconnectionPolicyTest.java
@@ -31,7 +31,7 @@ class ExponentialBackoffReconnectionPolicyTest {
                 .withMaxDelay(maxDelay)
                 .notMoreThan(maxAttempts)
                 .build();
-        val context = policy.initContext();
+        val context = policy.initState();
 
         for (var i = 0; i < iterations - 1; i++) {
             policy.getNextDelay(ReconnectionContext.of(-1, "some", context));

--- a/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderProxyTest.java
+++ b/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderProxyTest.java
@@ -185,7 +185,7 @@ class WsProviderProxyTest {
         }
     }
 
-    private <T> Map<?, ?> getHandlersOf(WsProvider<T> wsProvider) throws NoSuchFieldException, IllegalAccessException {
+    private <T> Map<?, ?> getHandlersOf(WsProvider wsProvider) throws NoSuchFieldException, IllegalAccessException {
         val handlersFields = wsProvider.getClass().getDeclaredField("handlers");
         handlersFields.setAccessible(true);
 


### PR DESCRIPTION
- made ReconnectionPolicy nongeneric
- renamed context to state to remove the confusion with `ReconnectionContext`. Another option might be to rename `initContext()` method to `initPolicyContext()`.